### PR TITLE
Add queue smoke-test guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ The primary desktop experience is:
 - SQLite for orchestration state, runs, decisions, notes, and PR-cycle tracking
 - Codex CLI as the local coding engine, with no separate API-key UX in Director OS
 
+## Dogfood Smoke Test
+
+When operating Director OS from this source checkout rather than an installed build, rebuild first so the local `dist` artifacts match the current source before using the CLI directly.
+
+1. `npm run build`
+2. `node apps/cli/dist/index.js sync`
+3. `node apps/cli/dist/index.js status`
+
+Expected result:
+
+- recently closed GitHub issues do not appear in `status.queue`
+- newly opened GitHub issues do appear in `status.queue`
+- the control-room queue only shows open, claimable work
+
+### Validated Local Smoke-Test Path
+
+When using the CLI directly, prefer the root `director` script so commands run against a fresh build instead of potentially stale compiled artifacts.
+
+Examples:
+
+- `npm run director -- status`
+- `npm run director -- sync`
+- `npm run director -- start`
+- `npm run director -- pause --reason "manual stop"`
+
+For desktop dogfooding, prefer:
+
+- `npm run desktop:start`
+
+This path rebuilds the desktop shell, renderer, core package, and CLI before launch.
+
 ## Scope
 
 ### MVP

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/web run build && npm --prefix apps/desktop run build && npm --prefix apps/cli run build",
+    "director": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/cli run build && node apps/cli/dist/index.js",
     "desktop:build": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/web run build && npm --prefix apps/desktop run build && npm --prefix apps/cli run build",
     "desktop:start": "npm run desktop:build && npm --prefix apps/desktop run start",
     "desktop:dev": "npm --prefix apps/cli run build && concurrently -k -n renderer,desktop-ts,electron -c auto \"npm --prefix apps/web run dev -- --host 127.0.0.1\" \"npm --prefix apps/desktop run build:watch\" \"wait-on tcp:4310 file:apps/desktop/dist/main.js && VITE_DEV_SERVER_URL=http://127.0.0.1:4310 npm --prefix apps/desktop run dev\"",

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -85,6 +85,11 @@ import {
   resolveRepoPath,
   viewPullRequest
 } from "./github.js";
+import {
+  inferWorkItemStatus,
+  selectActiveWorkItems,
+  selectQueuedWorkItems
+} from "./work-items.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -800,34 +805,6 @@ function inferPriorityBucket(status: WorkItemStatus): number {
     default:
       return 3;
   }
-}
-
-function inferWorkItemStatus(
-  issue: GitHubIssueRecord,
-  existing: WorkItemRecord | null,
-  linkedPr: GitHubPullRequestRecord | null
-): WorkItemStatus {
-  if (issue.state.toLowerCase() !== "open") {
-    return "completed";
-  }
-
-  if (linkedPr && linkedPr.state.toLowerCase() === "open") {
-    return "waiting_review";
-  }
-
-  if (existing && ["running", "planning", "waiting_decision"].includes(existing.status)) {
-    return existing.status;
-  }
-
-  if (issue.workflowState === "ready") {
-    return "ready";
-  }
-
-  if (issue.workflowState === "blocked") {
-    return "blocked";
-  }
-
-  return "queued";
 }
 
 async function recordEvent(
@@ -2889,12 +2866,8 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
     return {
       project: session.project,
       orchestrator,
-      queue: workItems
-        .filter((workItem) => ["queued", "ready", "planning"].includes(workItem.status))
-        .sort((left, right) => left.priorityBucket - right.priorityBucket || left.issueNumber - right.issueNumber),
-      activeWork: workItems
-        .filter((workItem) => ["running", "waiting_review", "waiting_decision"].includes(workItem.status))
-        .sort((left, right) => left.issueNumber - right.issueNumber),
+      queue: selectQueuedWorkItems(workItems),
+      activeWork: selectActiveWorkItems(workItems),
       decisions: decisionRows
         .map(mapDecisionRow)
         .filter((decision) => decision.status === "open")

--- a/packages/core/src/work-items.test.ts
+++ b/packages/core/src/work-items.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkItemRecord } from "@director-os/shared";
+
+import {
+  inferWorkItemStatus,
+  selectActiveWorkItems,
+  selectQueuedWorkItems
+} from "./work-items.js";
+
+function makeWorkItem(overrides: Partial<WorkItemRecord>): WorkItemRecord {
+  return {
+    id: overrides.id ?? 1,
+    projectId: overrides.projectId ?? 1,
+    issueNumber: overrides.issueNumber ?? 1,
+    parentIssueNumber: overrides.parentIssueNumber ?? null,
+    title: overrides.title ?? "Example issue",
+    summary: overrides.summary ?? "Example summary",
+    kind: overrides.kind ?? "task",
+    executionMode: overrides.executionMode ?? "worker",
+    ownerRole: overrides.ownerRole ?? "worker",
+    status: overrides.status ?? "queued",
+    priorityBucket: overrides.priorityBucket ?? 2,
+    activeRunId: overrides.activeRunId ?? null,
+    activePrNumber: overrides.activePrNumber ?? null,
+    lastSummary: overrides.lastSummary ?? null,
+    createdAt: overrides.createdAt ?? "2026-04-04T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-04-04T00:00:00.000Z"
+  };
+}
+
+describe("inferWorkItemStatus", () => {
+  it("marks closed issues as completed so they do not stay claimable", () => {
+    const status = inferWorkItemStatus(
+      {
+        state: "closed",
+        workflowState: "ready"
+      },
+      {
+        status: "ready"
+      },
+      null
+    );
+
+    expect(status).toBe("completed");
+  });
+
+  it("marks open issues with open pull requests as waiting_review", () => {
+    const status = inferWorkItemStatus(
+      {
+        state: "open",
+        workflowState: "ready"
+      },
+      null,
+      {
+        state: "open"
+      }
+    );
+
+    expect(status).toBe("waiting_review");
+  });
+});
+
+describe("selectQueuedWorkItems", () => {
+  it("filters completed items out of the visible queue and keeps open work ordered", () => {
+    const queue = selectQueuedWorkItems([
+      makeWorkItem({ issueNumber: 28, status: "queued", priorityBucket: 2 }),
+      makeWorkItem({ id: 2, issueNumber: 21, status: "completed", priorityBucket: 2 }),
+      makeWorkItem({ id: 3, issueNumber: 24, status: "ready", priorityBucket: 1 }),
+      makeWorkItem({ id: 4, issueNumber: 26, status: "planning", priorityBucket: 1 })
+    ]);
+
+    expect(queue.map((workItem) => workItem.issueNumber)).toEqual([24, 26, 28]);
+  });
+});
+
+describe("selectActiveWorkItems", () => {
+  it("returns only active work slices in issue order", () => {
+    const active = selectActiveWorkItems([
+      makeWorkItem({ issueNumber: 26, status: "waiting_review" }),
+      makeWorkItem({ id: 2, issueNumber: 28, status: "queued" }),
+      makeWorkItem({ id: 3, issueNumber: 24, status: "running" }),
+      makeWorkItem({ id: 4, issueNumber: 30, status: "waiting_decision" })
+    ]);
+
+    expect(active.map((workItem) => workItem.issueNumber)).toEqual([24, 26, 30]);
+  });
+});

--- a/packages/core/src/work-items.ts
+++ b/packages/core/src/work-items.ts
@@ -1,0 +1,49 @@
+import type {
+  GitHubIssueRecord,
+  GitHubPullRequestRecord,
+  WorkItemRecord,
+  WorkItemStatus
+} from "@director-os/shared";
+
+const QUEUED_STATUSES = new Set<WorkItemStatus>(["queued", "ready", "planning"]);
+const ACTIVE_STATUSES = new Set<WorkItemStatus>(["running", "waiting_review", "waiting_decision"]);
+
+export function inferWorkItemStatus(
+  issue: Pick<GitHubIssueRecord, "state" | "workflowState">,
+  existing: Pick<WorkItemRecord, "status"> | null,
+  linkedPr: Pick<GitHubPullRequestRecord, "state"> | null
+): WorkItemStatus {
+  if (issue.state.toLowerCase() !== "open") {
+    return "completed";
+  }
+
+  if (linkedPr && linkedPr.state.toLowerCase() === "open") {
+    return "waiting_review";
+  }
+
+  if (existing && ["running", "planning", "waiting_decision"].includes(existing.status)) {
+    return existing.status;
+  }
+
+  if (issue.workflowState === "ready") {
+    return "ready";
+  }
+
+  if (issue.workflowState === "blocked") {
+    return "blocked";
+  }
+
+  return "queued";
+}
+
+export function selectQueuedWorkItems(workItems: WorkItemRecord[]): WorkItemRecord[] {
+  return workItems
+    .filter((workItem) => QUEUED_STATUSES.has(workItem.status))
+    .sort((left, right) => left.priorityBucket - right.priorityBucket || left.issueNumber - right.issueNumber);
+}
+
+export function selectActiveWorkItems(workItems: WorkItemRecord[]): WorkItemRecord[] {
+  return workItems
+    .filter((workItem) => ACTIVE_STATUSES.has(workItem.status))
+    .sort((left, right) => left.issueNumber - right.issueNumber);
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,8 @@
     "src/github.ts",
     "src/index.ts",
     "src/server.ts",
-    "src/services.ts"
+    "src/services.ts",
+    "src/work-items.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
- extract work-item status and queue selection into a focused helper module
- add regression tests that lock in closed issues falling out of the visible queue
- add a supported `npm run director -- <command>` path so CLI smoke tests rebuild before running
- document the validated local smoke-test path in the README

## Context
Investigation from #28 showed the closed-issue queue problem was caused by stale compiled CLI artifacts after the merge, not by a source sync bug. This change adds regression coverage for the queue-selection behavior and gives dogfooding a rebuild-before-run path.

## Testing
- `npx vitest run packages/core/src/work-items.test.ts`
- `npm run build`
- `npm run director -- sync`
- `npm run director -- status`

Fixes #28
Part of #24