### PR TITLE
Make Chief of Staff chat the primary interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The product goal is not "full autonomy." The goal is a continuous operating loop
 The desired outcome is that the human mostly interacts through:
 
 - `Start` / `Pause`
-- director notes
-- rare escalation decisions
+- one ongoing Chief of Staff chat
+- rare CoS-authored escalation questions
 
 not through manually triggering every issue, review, or merge step.
 
@@ -32,27 +32,29 @@ The core local objects are:
 - `Run`: a Chief of Staff, lane, worker, review, validation, or PR-watch execution with logs and summaries
 - `Decision`: a real escalation, targeted either to the Chief of Staff or the human director
 - `PR cycle`: the local state machine around an open PR while it waits for automation, comments, revalidation, CoS review, and merge
-- `Director note`: freeform direction from the human, used when the org needs more work to pull
+- `Conversation thread`: one ongoing project chat between the director and the Chief of Staff
 
 ### Operating Loop
 
-1. The director adds a note or leaves existing GitHub issues as the durable backlog.
+1. The director talks to the Chief of Staff in one ongoing project thread or leaves existing GitHub issues as the durable backlog.
 2. The Chief of Staff syncs GitHub and chooses the next best ready slice.
 3. Larger or cross-cutting work is classified into a lane owner flow.
 4. Lane planning happens in a read-only Codex pass before any write-enabled execution starts.
 5. Bounded tasks go straight to worker execution.
 6. Workers implement code, validate locally, and open real non-draft PRs linked to numbered issues.
 7. PR cycles wait through automated review, address comments, rerun validation, and return to the Chief of Staff for independent merge judgment.
-8. Only non-obvious product calls, contradictory review outcomes, or "no work left" states escalate back to the human director.
+8. Workers and lane owners ask the Chief of Staff first when blocked.
+9. Only non-obvious product calls, contradictory review outcomes, or "no work left" states escalate back to the human director as explicit CoS-authored questions in the chat.
 
 ### UX Shape
 
-Director OS should feel like a calm control room rather than a ticket board.
+Director OS should feel like a calm Chief of Staff chat with an operational sidebar, not a ticket board.
 
 The primary desktop experience is:
 
 - setup and repair for repository, GitHub CLI, Codex CLI, and local workspace readiness
-- one control room with orchestrator state, queued work, active slices, PR cycles, escalations, recent runs, and director notes
+- one ongoing Chief of Staff chat thread for direction, clarification, and escalation replies
+- a secondary control-room sidebar with orchestrator state, queued work, active slices, PR cycles, escalations, and recent runs
 - explicit `Start`, `Pause`, and `Sync` controls instead of manual per-issue execution buttons
 
 ### Technical Direction
@@ -85,6 +87,8 @@ Examples:
 
 - `npm run director -- status`
 - `npm run director -- sync`
+- `npm run director -- conversation`
+- `npm run director -- message "Focus on setup reliability before UI polish."`
 - `npm run director -- start`
 - `npm run director -- pause --reason "manual stop"`
 
@@ -110,7 +114,7 @@ MVP includes:
 - worker execution via write-enabled Codex runs
 - real non-draft PR creation linked to numbered issues
 - PR-cycle waiting, review follow-up, revalidation, and merge readiness
-- a thin desktop control room for visibility and intervention
+- a primary Chief of Staff chat plus a thin desktop control room for visibility and intervention
 
 MVP does not need:
 
@@ -129,9 +133,9 @@ V1 includes:
 - stronger CoS sequencing and ranking
 - better autonomous handling of review comments and failing checks
 - richer lane ownership across parent/child issue slices
-- more informative human escalation cards
+- better serialization and prioritization of human-facing CoS questions
 - improved activity history and replayability
-- a more expressive director note to issue-expansion loop
+- a more expressive conversation-to-backlog expansion loop
 
 ### Vx
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,13 +4,14 @@ import open from "open";
 
 import {
   createDirectorServer,
+  getConversation,
   getDirectorStatus,
   initDirector,
   listDecisions,
   pauseOrchestrator,
   resolveDecision,
   startOrchestrator,
-  submitDirectorNote,
+  sendConversationMessage,
   syncProject
 } from "@director-os/core";
 
@@ -94,11 +95,27 @@ program
   });
 
 program
+  .command("conversation")
+  .description("Print the current Chief of Staff conversation thread")
+  .action(async () => {
+    console.log(JSON.stringify(await getConversation(), null, 2));
+  });
+
+program
+  .command("message")
+  .description("Send a message to the Chief of Staff chat")
+  .argument("<content...>", "The message to send")
+  .action(async (contentParts) => {
+    const result = await sendConversationMessage(contentParts.join(" "));
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+program
   .command("submit-note")
-  .description("Submit a freeform director note for the Chief of Staff")
+  .description("Alias for `message`")
   .argument("<content...>", "The note or product direction")
   .action(async (contentParts) => {
-    const result = await submitDirectorNote(contentParts.join(" "));
+    const result = await sendConversationMessage(contentParts.join(" "));
     console.log(JSON.stringify(result, null, 2));
   });
 

--- a/apps/desktop/src/preload.cts
+++ b/apps/desktop/src/preload.cts
@@ -1,8 +1,10 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 import type {
+  ConversationResponse,
   DecisionRecord,
   DecisionsResponse,
+  DirectorDesktopBridge,
   DirectorNoteRecord,
   DirectorOperationResponse,
   DirectorStatusResponse,
@@ -13,29 +15,15 @@ import type {
 
 import { IPC_CHANNELS } from "./protocol.js";
 
-interface DesktopBridge {
-  setup: {
-    getStatus(): Promise<SetupStatusResponse>;
-    probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;
-    runWorkspaceTest(input: SetupRepositoryDraft): Promise<SetupStatusResponse>;
-    complete(input: SetupRepositoryDraft): Promise<SetupStatusResponse>;
-  };
-  director: {
-    getStatus(): Promise<DirectorStatusResponse>;
-    start(): Promise<DirectorOperationResponse>;
-    pause(reason?: string): Promise<DirectorOperationResponse>;
-    sync(): Promise<DirectorOperationResponse>;
-    submitNote(content: string): Promise<DirectorNoteRecord>;
-    listDecisions(): Promise<DecisionsResponse>;
-    resolveDecision(decisionId: number, resolution: string): Promise<DecisionRecord>;
-  };
-}
-
 function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
   return ipcRenderer.invoke(channel, ...args) as Promise<T>;
 }
 
-const api: DesktopBridge = {
+const api: DirectorDesktopBridge = {
+  conversation: {
+    getConversation: () => invoke(IPC_CHANNELS.conversation.get),
+    sendMessage: (content: string) => invoke(IPC_CHANNELS.conversation.send, content)
+  },
   setup: {
     getStatus: () => invoke(IPC_CHANNELS.setup.getStatus),
     probeRepository: (input: SetupProbeRepositoryInput) =>

--- a/apps/desktop/src/protocol.ts
+++ b/apps/desktop/src/protocol.ts
@@ -1,4 +1,8 @@
 export const IPC_CHANNELS = {
+  conversation: {
+    get: "director:conversation:get",
+    send: "director:conversation:send"
+  },
   setup: {
     getStatus: "director:setup:get-status",
     probeRepository: "director:setup:probe-repository",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import type {
-  DecisionRecord,
-  DirectorNoteRecord,
+  ConversationMessageRecord,
+  ConversationResponse,
   DirectorStatusResponse,
   PrCycleRecord,
   RunRecord,
@@ -14,13 +14,13 @@ import type {
 import {
   completeSetup,
   fetchSetupStatus,
+  fetchConversation,
   fetchStatus,
   pauseDirector,
   probeRepository,
-  resolveEscalation,
   runWorkspaceTest,
+  sendMessage,
   startDirector,
-  submitNote,
   syncNow
 } from "./api";
 
@@ -33,13 +33,14 @@ export function App() {
   const [setupIntent, setSetupIntent] = useState<SetupIntent>("fresh");
   const [setupStatus, setSetupStatus] = useState<SetupStatusResponse | null>(null);
   const [status, setStatus] = useState<DirectorStatusResponse | null>(null);
+  const [conversation, setConversation] = useState<ConversationResponse | null>(null);
   const [repositoryPath, setRepositoryPath] = useState("");
   const [projectName, setProjectName] = useState("");
   const [worktreeRoot, setWorktreeRoot] = useState("");
   const [modelName, setModelName] = useState("");
-  const [noteInput, setNoteInput] = useState("");
-  const [resolutionInputs, setResolutionInputs] = useState<Record<number, string>>({});
+  const [messageInput, setMessageInput] = useState("");
   const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [conversationError, setConversationError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -52,7 +53,7 @@ export function App() {
     }
 
     const interval = window.setInterval(() => {
-      void refreshControlRoom();
+      void refreshWorkspace();
     }, 5_000);
 
     return () => {
@@ -63,6 +64,10 @@ export function App() {
   const codexCheck = setupStatus?.checks.find((check) => check.kind === "codex") ?? null;
   const codexBadge = deriveEngineBadge(codexCheck, setupStatus?.completed ?? false);
   const showSetup = shellMode === "setup" || !setupStatus?.completed;
+  const openQuestion = conversation?.openQuestion ?? null;
+  const composerPlaceholder = openQuestion
+    ? "Reply to the Chief of Staff..."
+    : "Message the Chief of Staff about the next slice, blocker, or product call.";
 
   const counts = useMemo(
     () => ({
@@ -89,7 +94,7 @@ export function App() {
         setShellMode("app");
         setSetupStep("complete");
         setSetupIntent("repair");
-        await refreshControlRoom();
+        await refreshWorkspace();
         return;
       }
 
@@ -104,12 +109,27 @@ export function App() {
     }
   }
 
-  async function refreshControlRoom() {
-    try {
-      setError(null);
-      setStatus(await fetchStatus());
-    } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : String(nextError));
+  async function refreshWorkspace() {
+    setError(null);
+
+    const [statusResult, conversationResult] = await Promise.allSettled([fetchStatus(), fetchConversation()]);
+
+    if (statusResult.status === "fulfilled") {
+      setStatus(statusResult.value);
+    } else {
+      setError(statusResult.reason instanceof Error ? statusResult.reason.message : String(statusResult.reason));
+    }
+
+    if (conversationResult.status === "fulfilled") {
+      setConversation(conversationResult.value);
+      setConversationError(null);
+    } else {
+      setConversation(null);
+      setConversationError(
+        conversationResult.reason instanceof Error
+          ? conversationResult.reason.message
+          : String(conversationResult.reason)
+      );
     }
   }
 
@@ -143,12 +163,12 @@ export function App() {
     }
   }
 
-  async function runControlAction(actionKey: string, runner: () => Promise<unknown>) {
+  async function runDashboardAction(actionKey: string, runner: () => Promise<unknown>) {
     try {
       setBusyAction(actionKey);
       setError(null);
       await runner();
-      await refreshControlRoom();
+      await refreshWorkspace();
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : String(nextError));
     } finally {
@@ -194,7 +214,7 @@ export function App() {
     await runSetupAction("setup-complete", async () => {
       const nextStatus = await completeSetup(setupStatus.repositoryDraft as SetupRepositoryDraft);
       setShellMode("app");
-      await refreshControlRoom();
+      await refreshWorkspace();
       return nextStatus;
     });
   }
@@ -206,31 +226,18 @@ export function App() {
     await refreshSetup({ forceSetup: true });
   }
 
-  async function handleResolveDecision(decision: DecisionRecord) {
-    const resolution = resolutionInputs[decision.id]?.trim();
-    if (!resolution) {
-      setError("Add a short resolution before resolving the escalation.");
+  async function handleSendMessage() {
+    const message = messageInput.trim();
+    if (!message) {
+      setError("Message the Chief of Staff first.");
       return;
     }
 
-    await runControlAction(`resolve-${decision.id}`, async () => {
-      await resolveEscalation(decision.id, resolution);
-      setResolutionInputs((current) => ({
-        ...current,
-        [decision.id]: ""
-      }));
-    });
-  }
-
-  async function handleSubmitNote() {
-    if (!noteInput.trim()) {
-      setError("Director note cannot be empty.");
-      return;
-    }
-
-    await runControlAction("submit-note", async () => {
-      await submitNote(noteInput.trim());
-      setNoteInput("");
+    await runDashboardAction("send-message", async () => {
+      const nextConversation = await sendMessage(message);
+      setConversation(nextConversation);
+      setMessageInput("");
+      await refreshWorkspace();
     });
   }
 
@@ -278,7 +285,7 @@ export function App() {
           <button
             className="action-button action-button-secondary"
             disabled={busyAction === "sync"}
-            onClick={() => void runControlAction("sync", () => syncNow())}
+            onClick={() => void runDashboardAction("sync", () => syncNow())}
           >
             Sync GitHub
           </button>
@@ -286,7 +293,7 @@ export function App() {
             <button
               className="action-button action-button-danger"
               disabled={busyAction === "pause"}
-              onClick={() => void runControlAction("pause", () => pauseDirector())}
+              onClick={() => void runDashboardAction("pause", () => pauseDirector())}
             >
               Pause
             </button>
@@ -294,7 +301,7 @@ export function App() {
             <button
               className="action-button action-button-primary"
               disabled={busyAction === "start"}
-              onClick={() => void runControlAction("start", () => startDirector())}
+              onClick={() => void runDashboardAction("start", () => startDirector())}
             >
               Start
             </button>
@@ -305,232 +312,246 @@ export function App() {
         </div>
       </header>
 
-      <main className="page-shell control-room-grid">
+      <main className="page-shell workspace-grid">
         {error ? <Banner tone="danger">{error}</Banner> : null}
+        {conversationError ? <Banner tone="warning">{conversationError}</Banner> : null}
 
-        <section className="panel hero-panel">
-          <div className="eyebrow">Continuous Chief Of Staff</div>
-          <div className="hero-row">
+        <section className="panel conversation-panel">
+          <div className="panel-header">
             <div>
-              <h1 className="hero-title">Run the product loop with a start and pause, not a queue of buttons.</h1>
-              <p className="hero-copy">
-                The Chief of Staff owns prioritization, sequencing, merge judgment, and escalation.
-                Lane owners and workers keep the GitHub-backed queue moving.
-              </p>
+              <div className="eyebrow">Chief of Staff chat</div>
+              <div className="section-title">One project thread, one place to answer the CoS.</div>
+              <div className="section-meta">
+                Workers ask here first. The CoS only escalates to you when there is a real product decision.
+              </div>
             </div>
-            <div className="hero-stats">
+            <div className="conversation-header-meta">
+              <StatusPill status={status?.orchestrator?.status ?? "idle"} />
+              <span>{conversation?.thread?.status ?? "active thread"}</span>
+            </div>
+          </div>
+
+          {openQuestion ? (
+            <div className="open-question-card">
+              <div className="eyebrow">Reply needed</div>
+              <div className="open-question-title">{openQuestion.summary ?? "Chief of Staff question"}</div>
+              <p className="open-question-copy">{openQuestion.content}</p>
+              <div className="open-question-meta">
+                {openQuestion.linkedIssueNumber ? <span>Issue #{openQuestion.linkedIssueNumber}</span> : null}
+                {openQuestion.linkedPrNumber ? <span>PR #{openQuestion.linkedPrNumber}</span> : null}
+                <span>{formatTimestamp(openQuestion.createdAt)}</span>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="conversation-stream">
+            {conversation?.messages?.length ? (
+              conversation.messages.map((message) => (
+                <ConversationBubble key={message.id} message={message} />
+              ))
+            ) : (
+              <div className="empty-state conversation-empty">
+                Say what you want the Chief of Staff to steer next. The project thread will grow from there.
+              </div>
+            )}
+          </div>
+
+          <div className="composer-card">
+            <div className="composer-head">
+              <div>
+                <div className="section-title">Message the Chief of Staff</div>
+                <div className="section-meta">
+                  {openQuestion
+                    ? "Reply here to unblock the current question."
+                    : "Send a new direction, clarification, or boundary in plain language."}
+                </div>
+              </div>
+              <span className={`check-pill ${openQuestion ? "check-pill-needs-action" : "check-pill-ready"}`}>
+                {openQuestion ? "Reply needed" : "Open thread"}
+              </span>
+            </div>
+            <textarea
+              className="text-field text-area composer-input"
+              value={messageInput}
+              onChange={(event) => setMessageInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  void handleSendMessage();
+                }
+              }}
+              placeholder={composerPlaceholder}
+            />
+            <div className="composer-actions">
+              <button
+                className="action-button action-button-primary"
+                disabled={busyAction === "send-message" || !messageInput.trim()}
+                onClick={() => void handleSendMessage()}
+              >
+                Send to CoS
+              </button>
+              <button
+                className="action-button action-button-secondary"
+                disabled={!messageInput.trim()}
+                onClick={() => setMessageInput("")}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="sidebar-column">
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Current stance</div>
+                <div className="section-meta">{status?.orchestrator?.lastSummary ?? "The control room is ready."}</div>
+              </div>
+            </div>
+            <div className="hero-stats sidebar-stats">
               <StatCard label="Queue" value={String(counts.queued)} />
               <StatCard label="Active" value={String(counts.active)} />
               <StatCard label="Escalations" value={String(counts.decisions)} />
               <StatCard label="Open PRs" value={String(counts.prs)} />
             </div>
-          </div>
-          <div className="hero-meta">
-            <StatusPill status={status?.orchestrator?.status ?? "idle"} />
-            <span>{status?.orchestrator?.lastSummary ?? "The control room is ready."}</span>
-          </div>
-        </section>
-
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">Queued work</div>
-              <div className="section-meta">GitHub remains the durable backlog. Director OS handles the loop around it.</div>
+            <div className="hero-meta">
+              <span className={`status-pill status-pill-${(status?.orchestrator?.status ?? "idle").replace("_", "-")}`}>
+                {status?.orchestrator?.status ?? "idle"}
+              </span>
+              <span>The Chief of Staff loop stays local and synchronized with GitHub.</span>
             </div>
-          </div>
-          <ItemList<WorkItemRecord>
-            empty="No queueable work yet."
-            items={status?.queue ?? []}
-            render={(item) => (
-              <div className="list-row" key={item.id}>
-                <div>
-                  <div className="list-title">#{item.issueNumber} {item.title}</div>
-                  <div className="list-meta">
-                    <span>{item.executionMode}</span>
-                    <span>{item.kind}</span>
-                    <span>{item.status}</span>
-                  </div>
-                </div>
-                <div className="list-note">{item.lastSummary ?? item.summary}</div>
+          </section>
+
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Open escalations</div>
+                <div className="section-meta">Read-only view of the questions the CoS still wants resolved.</div>
               </div>
-            )}
-          />
-        </section>
-
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">Active slices</div>
-              <div className="section-meta">Work already in motion across lane planning, implementation, PR review, and decisions.</div>
             </div>
-          </div>
-          <ItemList<WorkItemRecord>
-            empty="Nothing is active right now."
-            items={status?.activeWork ?? []}
-            render={(item) => (
-              <div className="list-row" key={item.id}>
-                <div>
-                  <div className="list-title">#{item.issueNumber} {item.title}</div>
-                  <div className="list-meta">
-                    <span>{item.executionMode}</span>
-                    <span>{item.status}</span>
-                    {item.activePrNumber ? <span>PR #{item.activePrNumber}</span> : null}
+            <ItemList<DirectorStatusResponse["decisions"][number]>
+              empty="No human escalations are waiting right now."
+              items={status?.decisions ?? []}
+              render={(decision) => (
+                <div className="compact-card" key={decision.id}>
+                  <div className="compact-card-head">
+                    <div className="list-title">{decision.title}</div>
+                    <span className="check-pill check-pill-needs-action">{decision.target.replace("_", " ")}</span>
                   </div>
+                  <div className="compact-card-meta">
+                    {decision.issueNumber ? <span>Issue #{decision.issueNumber}</span> : null}
+                    {decision.prNumber ? <span>PR #{decision.prNumber}</span> : null}
+                  </div>
+                  <div className="list-note">{decision.summary}</div>
                 </div>
-                <div className="list-note">{item.lastSummary ?? item.summary}</div>
-              </div>
-            )}
-          />
-        </section>
+              )}
+            />
+          </section>
 
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">Escalations</div>
-              <div className="section-meta">Only non-obvious product calls or blocked states should land here.</div>
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Queued work</div>
+                <div className="section-meta">GitHub remains the durable backlog behind the chat.</div>
+              </div>
             </div>
-          </div>
-          {(status?.decisions ?? []).length === 0 ? (
-            <div className="empty-state">No human escalations are waiting right now.</div>
-          ) : (
-            <div className="decision-stack">
-              {(status?.decisions ?? []).map((decision: DecisionRecord) => (
-                <article className="decision-card" key={decision.id}>
-                  <div className="decision-head">
-                    <div>
-                      <div className="list-title">{decision.title}</div>
-                      <div className="list-meta">
-                        <span>{decision.target}</span>
-                        {decision.issueNumber ? <span>Issue #{decision.issueNumber}</span> : null}
-                        {decision.prNumber ? <span>PR #{decision.prNumber}</span> : null}
-                      </div>
+            <ItemList<WorkItemRecord>
+              empty="No queueable work yet."
+              items={status?.queue ?? []}
+              render={(item) => (
+                <div className="list-row compact-list-row" key={item.id}>
+                  <div>
+                    <div className="list-title">#{item.issueNumber} {item.title}</div>
+                    <div className="list-meta">
+                      <span>{item.executionMode}</span>
+                      <span>{item.kind}</span>
+                      <span>{item.status}</span>
                     </div>
                   </div>
-                  <p className="decision-copy">{decision.summary}</p>
-                  <div className="decision-block">
-                    <strong>Recommendation</strong>
-                    <p>{decision.recommendation}</p>
-                  </div>
-                  <div className="decision-block">
-                    <strong>Rationale</strong>
-                    <p>{decision.rationale}</p>
-                  </div>
-                  <textarea
-                    className="text-field text-area"
-                    value={resolutionInputs[decision.id] ?? ""}
-                    onChange={(event) =>
-                      setResolutionInputs((current) => ({
-                        ...current,
-                        [decision.id]: event.target.value
-                      }))
-                    }
-                    placeholder="Write the decision or direction that should unblock this."
-                  />
-                  <div className="decision-actions">
-                    <button
-                      className="action-button action-button-primary"
-                      disabled={busyAction === `resolve-${decision.id}`}
-                      onClick={() => void handleResolveDecision(decision)}
-                    >
-                      Resolve escalation
-                    </button>
-                  </div>
-                </article>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">PR cycles</div>
-              <div className="section-meta">Automation waits, review follow-up, revalidation, and merge readiness in one stream.</div>
-            </div>
-          </div>
-          <ItemList<PrCycleRecord>
-            empty="No open PR cycles yet."
-            items={status?.prCycles ?? []}
-            render={(cycle) => (
-              <div className="list-row" key={cycle.id}>
-                <div>
-                  <div className="list-title">PR #{cycle.prNumber} for issue #{cycle.issueNumber}</div>
-                  <div className="list-meta">
-                    <span>{cycle.status}</span>
-                    {cycle.automationWindowEndsAt ? <span>Window ends {formatTimestamp(cycle.automationWindowEndsAt)}</span> : null}
-                  </div>
+                  <div className="list-note">{item.lastSummary ?? item.summary}</div>
                 </div>
-                <div className="list-note">{cycle.summary}</div>
-              </div>
-            )}
-          />
-        </section>
+              )}
+            />
+          </section>
 
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">Recent runs</div>
-              <div className="section-meta">Chief of Staff, lane, worker, and review runs with their latest summaries.</div>
-            </div>
-          </div>
-          <ItemList<RunRecord>
-            empty="No runs recorded yet."
-            items={status?.recentRuns ?? []}
-            render={(run) => (
-              <div className="list-row" key={run.id}>
-                <div>
-                  <div className="list-title">{run.role} • {run.phase}</div>
-                  <div className="list-meta">
-                    <span>{run.status}</span>
-                    {run.issueNumber ? <span>Issue #{run.issueNumber}</span> : null}
-                    {run.prNumber ? <span>PR #{run.prNumber}</span> : null}
-                  </div>
-                </div>
-                <div className="list-note">{run.summary}</div>
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Active slices</div>
+                <div className="section-meta">In-flight lane, worker, review, and PR watch runs.</div>
               </div>
-            )}
-          />
-        </section>
+            </div>
+            <ItemList<WorkItemRecord>
+              empty="Nothing is active right now."
+              items={status?.activeWork ?? []}
+              render={(item) => (
+                <div className="list-row compact-list-row" key={item.id}>
+                  <div>
+                    <div className="list-title">#{item.issueNumber} {item.title}</div>
+                    <div className="list-meta">
+                      <span>{item.executionMode}</span>
+                      <span>{item.status}</span>
+                      {item.activePrNumber ? <span>PR #{item.activePrNumber}</span> : null}
+                    </div>
+                  </div>
+                  <div className="list-note">{item.lastSummary ?? item.summary}</div>
+                </div>
+              )}
+            />
+          </section>
 
-        <section className="panel note-panel">
-          <div className="panel-header">
-            <div>
-              <div className="section-title">Director notes</div>
-              <div className="section-meta">Drop a new product direction here when the Chief of Staff needs more fuel.</div>
-            </div>
-          </div>
-          <textarea
-            className="text-field text-area"
-            value={noteInput}
-            onChange={(event) => setNoteInput(event.target.value)}
-            placeholder="Describe the next product direction or constraint in plain language."
-          />
-          <div className="note-actions">
-            <button
-              className="action-button action-button-primary"
-              disabled={busyAction === "submit-note"}
-              onClick={() => void handleSubmitNote()}
-            >
-              Submit note
-            </button>
-          </div>
-          <ItemList<DirectorNoteRecord>
-            empty="No director notes recorded yet."
-            items={status?.notes ?? []}
-            render={(note) => (
-              <div className="list-row" key={note.id}>
-                <div>
-                  <div className="list-title">Note #{note.id}</div>
-                  <div className="list-meta">
-                    <span>{note.status}</span>
-                    <span>{formatTimestamp(note.createdAt)}</span>
-                  </div>
-                </div>
-                <div className="list-note">{note.content}</div>
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">PR cycles</div>
+                <div className="section-meta">Automation waits, review follow-up, and merge readiness.</div>
               </div>
-            )}
-          />
-        </section>
+            </div>
+            <ItemList<PrCycleRecord>
+              empty="No open PR cycles yet."
+              items={status?.prCycles ?? []}
+              render={(cycle) => (
+                <div className="list-row compact-list-row" key={cycle.id}>
+                  <div>
+                    <div className="list-title">PR #{cycle.prNumber} for issue #{cycle.issueNumber}</div>
+                    <div className="list-meta">
+                      <span>{cycle.status}</span>
+                      {cycle.automationWindowEndsAt ? <span>Window ends {formatTimestamp(cycle.automationWindowEndsAt)}</span> : null}
+                    </div>
+                  </div>
+                  <div className="list-note">{cycle.summary}</div>
+                </div>
+              )}
+            />
+          </section>
+
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Recent runs</div>
+                <div className="section-meta">Chief of Staff, lane, worker, and review runs.</div>
+              </div>
+            </div>
+            <ItemList<RunRecord>
+              empty="No runs recorded yet."
+              items={status?.recentRuns ?? []}
+              render={(run) => (
+                <div className="list-row compact-list-row" key={run.id}>
+                  <div>
+                    <div className="list-title">{run.role} • {run.phase}</div>
+                    <div className="list-meta">
+                      <span>{run.status}</span>
+                      {run.issueNumber ? <span>Issue #{run.issueNumber}</span> : null}
+                      {run.prNumber ? <span>PR #{run.prNumber}</span> : null}
+                    </div>
+                  </div>
+                  <div className="list-note">{run.summary}</div>
+                </div>
+              )}
+            />
+          </section>
+        </aside>
       </main>
     </div>
   );
@@ -733,6 +754,42 @@ function SetupStepCard(props: {
 
 function StatusPill(props: { status: string }) {
   return <span className={`status-pill status-pill-${props.status.replace("_", "-")}`}>{props.status.replace("_", " ")}</span>;
+}
+
+function ConversationBubble(props: { message: ConversationMessageRecord }) {
+  const toneClass =
+    props.message.role === "director"
+      ? "conversation-message-director"
+      : props.message.role === "chief_of_staff"
+        ? "conversation-message-cos"
+        : "conversation-message-system";
+
+  const kindLabel = props.message.kind.replace("_", " ");
+  const roleLabel =
+    props.message.role === "director"
+      ? "Director"
+      : props.message.role === "chief_of_staff"
+        ? "Chief of Staff"
+        : "System";
+
+  return (
+    <article className={`conversation-message ${toneClass} ${props.message.isOpenQuestion ? "conversation-message-open" : ""}`}>
+      <div className="conversation-message-head">
+        <div className="conversation-message-labels">
+          <span className="conversation-role">{roleLabel}</span>
+          <span className="conversation-kind">{kindLabel}</span>
+          {props.message.isOpenQuestion ? <span className="conversation-open">Needs reply</span> : null}
+        </div>
+        <span className="conversation-time">{formatTimestamp(props.message.createdAt)}</span>
+      </div>
+      {props.message.summary ? <div className="conversation-summary">{props.message.summary}</div> : null}
+      <p className="conversation-body">{props.message.content}</p>
+      <div className="conversation-links">
+        {props.message.linkedIssueNumber ? <span>Issue #{props.message.linkedIssueNumber}</span> : null}
+        {props.message.linkedPrNumber ? <span>PR #{props.message.linkedPrNumber}</span> : null}
+      </div>
+    </article>
+  );
 }
 
 function StatCard(props: { label: string; value: string }) {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,7 +1,11 @@
 import type {
+  ConversationMessageRecord,
+  ConversationResponse,
+  ConversationThreadRecord,
   DecisionRecord,
   DecisionsResponse,
   DirectorClient,
+  DirectorDesktopBridge,
   DirectorNoteRecord,
   DirectorOperationResponse,
   DirectorStatusResponse,
@@ -15,6 +19,9 @@ import type {
 } from "@director-os/shared";
 
 export type {
+  ConversationMessageRecord,
+  ConversationResponse,
+  ConversationThreadRecord,
   DecisionRecord,
   DecisionsResponse,
   DirectorNoteRecord,
@@ -30,26 +37,13 @@ export type {
 
 declare global {
   interface Window {
-    director?: ElectronDirectorBridge;
+    director?: DirectorDesktopBridge;
   }
 }
 
-interface ElectronDirectorBridge {
-  setup: {
-    getStatus(): Promise<SetupStatusResponse>;
-    probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;
-    runWorkspaceTest(repositoryDraft: SetupRepositoryDraft): Promise<SetupStatusResponse>;
-    complete(repositoryDraft: SetupRepositoryDraft): Promise<SetupStatusResponse>;
-  };
-  director: {
-    getStatus(): Promise<DirectorStatusResponse>;
-    start(): Promise<DirectorOperationResponse>;
-    pause(reason?: string): Promise<DirectorOperationResponse>;
-    sync(): Promise<DirectorOperationResponse>;
-    submitNote(content: string): Promise<DirectorNoteRecord>;
-    listDecisions(): Promise<DecisionsResponse>;
-    resolveDecision(decisionId: number, resolution: string): Promise<DecisionRecord>;
-  };
+interface WebDirectorClient extends DirectorClient {
+  getConversation(): Promise<ConversationResponse>;
+  sendMessage(content: string): Promise<ConversationResponse>;
 }
 
 function hasElectronBridge(): boolean {
@@ -80,8 +74,14 @@ async function requestJson<T>(input: string, init?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
-function createHttpDirectorClient(): DirectorClient {
+function createHttpDirectorClient(): WebDirectorClient {
   return {
+    getConversation: () => requestJson<ConversationResponse>("/api/conversation"),
+    sendMessage: (content: string) =>
+      requestJson<ConversationResponse>("/api/conversation", {
+        method: "POST",
+        body: JSON.stringify({ content })
+      }),
     getSetupStatus: () => requestJson<SetupStatusResponse>("/api/setup/status"),
     probeRepository: (input: SetupProbeRepositoryInput) =>
       requestJson<SetupStatusResponse>("/api/setup/probe-repository", {
@@ -126,8 +126,10 @@ function createHttpDirectorClient(): DirectorClient {
   };
 }
 
-function createIpcDirectorClient(bridge: ElectronDirectorBridge): DirectorClient {
+function createIpcDirectorClient(bridge: DirectorDesktopBridge): WebDirectorClient {
   return {
+    getConversation: () => bridge.conversation.getConversation(),
+    sendMessage: (content: string) => bridge.conversation.sendMessage(content),
     getSetupStatus: () => bridge.setup.getStatus(),
     probeRepository: (input: SetupProbeRepositoryInput) => bridge.setup.probeRepository(input),
     runWorkspaceTest: (repositoryDraft: SetupRepositoryDraft) =>
@@ -144,18 +146,26 @@ function createIpcDirectorClient(bridge: ElectronDirectorBridge): DirectorClient
   };
 }
 
-let cachedClient: DirectorClient | null = null;
+let cachedClient: WebDirectorClient | null = null;
 
-export function getDirectorClient(): DirectorClient {
+export function getDirectorClient(): WebDirectorClient {
   if (cachedClient) {
     return cachedClient;
   }
 
   cachedClient = hasElectronBridge()
-    ? createIpcDirectorClient(window.director as ElectronDirectorBridge)
+    ? createIpcDirectorClient(window.director as DirectorDesktopBridge)
     : createHttpDirectorClient();
 
   return cachedClient;
+}
+
+export async function fetchConversation(): Promise<ConversationResponse> {
+  return getDirectorClient().getConversation();
+}
+
+export async function sendMessage(content: string): Promise<ConversationResponse> {
+  return getDirectorClient().sendMessage(content);
 }
 
 export async function fetchSetupStatus(): Promise<SetupStatusResponse> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -179,10 +179,16 @@ button {
   padding-top: 24px;
 }
 
+.workspace-grid,
 .control-room-grid,
 .setup-grid {
   display: grid;
   gap: 18px;
+}
+
+.workspace-grid {
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.85fr);
+  align-items: start;
 }
 
 .control-room-grid {
@@ -313,6 +319,214 @@ button {
   gap: 16px;
   align-items: start;
   margin-bottom: 16px;
+}
+
+.conversation-panel {
+  min-height: calc(100vh - 160px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.conversation-header-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  color: var(--text-soft);
+}
+
+.conversation-stream {
+  display: grid;
+  gap: 12px;
+  flex: 1;
+  min-height: 320px;
+  max-height: calc(100vh - 460px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.conversation-empty {
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.open-question-card,
+.composer-card,
+.sidebar-card,
+.conversation-message {
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.open-question-card {
+  padding: 16px;
+  background: color-mix(in srgb, var(--panel-strong) 86%, white 14%);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.open-question-title {
+  margin-top: 6px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.open-question-copy {
+  margin: 10px 0 0;
+  color: var(--text-soft);
+}
+
+.open-question-meta,
+.conversation-links,
+.compact-card-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--text-faint);
+  font-size: 0.86rem;
+}
+
+.conversation-message {
+  padding: 14px 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.conversation-message-director {
+  background: color-mix(in srgb, var(--panel-strong) 84%, white 16%);
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+}
+
+.conversation-message-cos {
+  background: color-mix(in srgb, var(--success) 6%, white 94%);
+  border-color: color-mix(in srgb, var(--success) 24%, var(--border));
+}
+
+.conversation-message-system {
+  background: color-mix(in srgb, var(--bg-soft) 50%, white 50%);
+}
+
+.conversation-message-open {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--warning) 26%, transparent);
+}
+
+.conversation-message-head,
+.composer-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.conversation-message-labels {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.conversation-role,
+.conversation-kind,
+.conversation-open {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.conversation-role {
+  background: rgba(34, 29, 23, 0.08);
+}
+
+.conversation-kind {
+  background: rgba(123, 83, 54, 0.1);
+  color: var(--accent-strong);
+}
+
+.conversation-open {
+  background: color-mix(in srgb, var(--warning) 14%, white 86%);
+  color: var(--warning);
+}
+
+.conversation-time {
+  color: var(--text-faint);
+  font-size: 0.84rem;
+}
+
+.conversation-summary {
+  color: var(--text-soft);
+  font-weight: 600;
+}
+
+.conversation-body {
+  margin: 0;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.composer-card {
+  padding: 16px;
+  display: grid;
+  gap: 14px;
+}
+
+.composer-input {
+  min-height: 118px;
+}
+
+.composer-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.sidebar-column {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.sidebar-card {
+  padding: 16px;
+}
+
+.sidebar-stats {
+  margin-bottom: 12px;
+}
+
+.sidebar-stats .stat-card {
+  padding: 12px;
+}
+
+.compact-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.42);
+  display: grid;
+  gap: 8px;
+}
+
+.compact-card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: start;
+}
+
+.compact-list-row {
+  padding: 12px;
 }
 
 .section-title {
@@ -477,6 +691,12 @@ button {
   border-color: color-mix(in srgb, var(--danger) 22%, var(--border));
 }
 
+.banner-warning {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 8%, white 92%);
+  border-color: color-mix(in srgb, var(--warning) 22%, var(--border));
+}
+
 .empty-state {
   border: 1px dashed var(--border);
   border-radius: 16px;
@@ -486,8 +706,17 @@ button {
 @media (max-width: 1080px) {
   .control-room-grid,
   .setup-grid,
-  .hero-row {
+  .hero-row,
+  .workspace-grid {
     grid-template-columns: 1fr;
+  }
+
+  .conversation-panel {
+    min-height: auto;
+  }
+
+  .conversation-stream {
+    max-height: none;
   }
 }
 
@@ -503,5 +732,10 @@ button {
 
   .hero-title {
     max-width: none;
+  }
+
+  .composer-actions,
+  .header-actions {
+    width: 100%;
   }
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -6,7 +6,7 @@ import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core
 
 import { ensureRuntimeDirectories, resolveRuntimePaths, type RuntimePaths } from "./config.js";
 
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 4;
 const jsonText = (name: string) => text(name, { mode: "json" });
 
 export const projectsTable = sqliteTable(
@@ -52,6 +52,41 @@ export const directorNotesTable = sqliteTable("director_notes", {
   projectId: integer("project_id").notNull(),
   content: text("content").notNull(),
   status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const conversationThreadsTable = sqliteTable(
+  "conversation_threads",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    projectId: integer("project_id").notNull(),
+    title: text("title").notNull(),
+    status: text("status").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull()
+  },
+  (table) => ({
+    conversationProjectIdx: uniqueIndex("conversation_threads_project_idx").on(table.projectId)
+  })
+);
+
+export const conversationMessagesTable = sqliteTable("conversation_messages", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  threadId: integer("thread_id").notNull(),
+  projectId: integer("project_id").notNull(),
+  role: text("role").notNull(),
+  kind: text("kind").notNull(),
+  content: text("content").notNull(),
+  summary: text("summary"),
+  linkedIssueNumber: integer("linked_issue_number"),
+  linkedPrNumber: integer("linked_pr_number"),
+  isOpenQuestion: integer("is_open_question", { mode: "boolean" }).notNull().default(false),
+  workItemId: integer("work_item_id"),
+  issueNumber: integer("issue_number"),
+  prNumber: integer("pr_number"),
+  decisionId: integer("decision_id"),
+  runId: integer("run_id"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()
 });
@@ -106,6 +141,9 @@ export const decisionsTable = sqliteTable("decisions", {
   workItemId: integer("work_item_id"),
   issueNumber: integer("issue_number"),
   prNumber: integer("pr_number"),
+  requestedByRunId: integer("requested_by_run_id"),
+  questionMessageId: integer("question_message_id"),
+  resolutionMessageId: integer("resolution_message_id"),
   target: text("target").notNull(),
   title: text("title").notNull(),
   summary: text("summary").notNull(),
@@ -231,6 +269,8 @@ export const schema = {
   projectsTable,
   orchestratorStateTable,
   directorNotesTable,
+  conversationThreadsTable,
+  conversationMessagesTable,
   workItemsTable,
   runsTable,
   decisionsTable,
@@ -284,6 +324,34 @@ create table if not exists director_notes (
   created_at text not null,
   updated_at text not null
 );
+create table if not exists conversation_threads (
+  id integer primary key autoincrement,
+  project_id integer not null,
+  title text not null,
+  status text not null,
+  created_at text not null,
+  updated_at text not null
+);
+create unique index if not exists conversation_threads_project_idx on conversation_threads(project_id);
+create table if not exists conversation_messages (
+  id integer primary key autoincrement,
+  thread_id integer not null,
+  project_id integer not null,
+  role text not null,
+  kind text not null,
+  content text not null,
+  summary text,
+  linked_issue_number integer,
+  linked_pr_number integer,
+  is_open_question integer not null default 0,
+  work_item_id integer,
+  issue_number integer,
+  pr_number integer,
+  decision_id integer,
+  run_id integer,
+  created_at text not null,
+  updated_at text not null
+);
 create table if not exists work_items (
   id integer primary key autoincrement,
   project_id integer not null,
@@ -327,6 +395,9 @@ create table if not exists decisions (
   work_item_id integer,
   issue_number integer,
   pr_number integer,
+  requested_by_run_id integer,
+  question_message_id integer,
+  resolution_message_id integer,
   target text not null,
   title text not null,
   summary text not null,
@@ -431,6 +502,11 @@ export async function openDatabase(paths = resolveRuntimePaths()): Promise<OpenD
   };
 }
 
+function columnExists(sqlite: Database.Database, tableName: string, columnName: string): boolean {
+  const rows = sqlite.pragma(`table_info(${tableName})`) as Array<{ name?: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
 export function migrateDatabase(sqlite: Database.Database): void {
   const version = Number(sqlite.pragma("user_version", { simple: true }) ?? 0);
 
@@ -444,6 +520,31 @@ export function migrateDatabase(sqlite: Database.Database): void {
   }
 
   sqlite.exec(bootstrapSql);
+
+  if (!columnExists(sqlite, "conversation_threads", "status")) {
+    sqlite.exec("alter table conversation_threads add column status text not null default 'active';");
+  }
+  if (!columnExists(sqlite, "conversation_messages", "summary")) {
+    sqlite.exec("alter table conversation_messages add column summary text;");
+  }
+  if (!columnExists(sqlite, "conversation_messages", "linked_issue_number")) {
+    sqlite.exec("alter table conversation_messages add column linked_issue_number integer;");
+  }
+  if (!columnExists(sqlite, "conversation_messages", "linked_pr_number")) {
+    sqlite.exec("alter table conversation_messages add column linked_pr_number integer;");
+  }
+  if (!columnExists(sqlite, "conversation_messages", "is_open_question")) {
+    sqlite.exec("alter table conversation_messages add column is_open_question integer not null default 0;");
+  }
+  if (!columnExists(sqlite, "decisions", "requested_by_run_id")) {
+    sqlite.exec("alter table decisions add column requested_by_run_id integer;");
+  }
+  if (!columnExists(sqlite, "decisions", "question_message_id")) {
+    sqlite.exec("alter table decisions add column question_message_id integer;");
+  }
+  if (!columnExists(sqlite, "decisions", "resolution_message_id")) {
+    sqlite.exec("alter table decisions add column resolution_message_id integer;");
+  }
   sqlite.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
 }
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -7,6 +7,7 @@ import Fastify from "fastify";
 
 import {
   completeSetup,
+  getConversation,
   getDirectorStatus,
   getSetupStatus,
   listDecisions,
@@ -15,6 +16,7 @@ import {
   resolveDecision,
   runWorkspaceSetupTest,
   startOrchestrator,
+  sendConversationMessage,
   submitDirectorNote,
   syncProject
 } from "./services.js";
@@ -41,6 +43,7 @@ export async function createDirectorServer() {
   }));
 
   app.get("/api/setup/status", async () => getSetupStatus());
+  app.get("/api/conversation", async () => getConversation());
 
   app.post<{
     Body: {
@@ -83,6 +86,9 @@ export async function createDirectorServer() {
 
   app.get("/api/status", async () => getDirectorStatus());
   app.get("/api/decisions", async () => listDecisions());
+  app.post<{ Body: { content: string } }>("/api/conversation", async (request) =>
+    sendConversationMessage(request.body.content)
+  );
 
   app.post("/api/start", async () => startOrchestrator());
   app.post<{ Body: { reason?: string } }>("/api/pause", async (request) =>

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -9,6 +9,9 @@ import { desc, eq } from "drizzle-orm";
 import {
   DIRECTOR_LABEL_PREFIX,
   type AgentResultEnvelope,
+  type ConversationMessageRecord,
+  type ConversationResponse,
+  type ConversationThreadRecord,
   type DecisionRecord,
   type DecisionsResponse,
   type DirectorNoteRecord,
@@ -51,6 +54,8 @@ import {
 } from "./config.js";
 import {
   asJson,
+  conversationMessagesTable,
+  conversationThreadsTable,
   decisionsTable,
   directorNotesTable,
   eventsTable,
@@ -285,6 +290,9 @@ function mapDecisionRow(row: typeof decisionsTable.$inferSelect): DecisionRecord
     workItemId: row.workItemId ?? null,
     issueNumber: row.issueNumber ?? null,
     prNumber: row.prNumber ?? null,
+    requestedByRunId: row.requestedByRunId ?? null,
+    questionMessageId: row.questionMessageId ?? null,
+    resolutionMessageId: row.resolutionMessageId ?? null,
     target: row.target as DecisionRecord["target"],
     title: row.title,
     summary: row.summary,
@@ -292,6 +300,38 @@ function mapDecisionRow(row: typeof decisionsTable.$inferSelect): DecisionRecord
     rationale: row.rationale,
     status: row.status as DecisionRecord["status"],
     resolution: row.resolution ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function mapConversationThreadRow(
+  row: typeof conversationThreadsTable.$inferSelect
+): ConversationThreadRecord {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    title: row.title,
+    status: row.status as ConversationThreadRecord["status"],
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function mapConversationMessageRow(
+  row: typeof conversationMessagesTable.$inferSelect
+): ConversationMessageRecord {
+  return {
+    id: row.id,
+    threadId: row.threadId,
+    projectId: row.projectId,
+    role: row.role as ConversationMessageRecord["role"],
+    kind: row.kind as ConversationMessageRecord["kind"],
+    content: row.content,
+    summary: row.summary ?? summarizeText(row.content),
+    linkedIssueNumber: row.linkedIssueNumber ?? row.issueNumber ?? null,
+    linkedPrNumber: row.linkedPrNumber ?? row.prNumber ?? null,
+    isOpenQuestion: row.isOpenQuestion ?? false,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt
   };
@@ -1127,6 +1167,265 @@ async function updateRun(
   return mapped;
 }
 
+async function ensureConversationThread(
+  session: ProjectSession
+): Promise<ConversationThreadRecord> {
+  const existingRows = await session.db
+    .select()
+    .from(conversationThreadsTable)
+    .where(eq(conversationThreadsTable.projectId, session.project.id))
+    .limit(1);
+
+  let thread = existingRows[0] ? mapConversationThreadRow(existingRows[0]) : null;
+  if (!thread) {
+    const timestamp = nowIso();
+    const result = await session.db.insert(conversationThreadsTable).values({
+      projectId: session.project.id,
+      title: `${session.project.name} Chief of Staff`,
+      status: "active",
+      createdAt: timestamp,
+      updatedAt: timestamp
+    });
+    const row = await session.db
+      .select()
+      .from(conversationThreadsTable)
+      .where(eq(conversationThreadsTable.id, Number(result.lastInsertRowid)))
+      .limit(1);
+    thread = mapConversationThreadRow(assertPresent(row[0], "Conversation thread missing after insert."));
+  }
+
+  const messageRows = await session.db
+    .select()
+    .from(conversationMessagesTable)
+    .where(eq(conversationMessagesTable.threadId, thread.id))
+    .limit(1);
+  if (messageRows[0]) {
+    return thread;
+  }
+
+  const noteRows = await session.db
+    .select()
+    .from(directorNotesTable)
+    .where(eq(directorNotesTable.projectId, session.project.id));
+  for (const note of noteRows.map(mapNoteRow).sort((left, right) => left.createdAt.localeCompare(right.createdAt))) {
+    await session.db.insert(conversationMessagesTable).values({
+      threadId: thread.id,
+      projectId: session.project.id,
+      role: "director",
+      kind: "human_message",
+      content: note.content,
+      summary: summarizeText(note.content),
+      linkedIssueNumber: null,
+      linkedPrNumber: null,
+      isOpenQuestion: false,
+      workItemId: null,
+      issueNumber: null,
+      prNumber: null,
+      decisionId: null,
+      runId: null,
+      createdAt: note.createdAt,
+      updatedAt: note.updatedAt
+    });
+  }
+
+  return thread;
+}
+
+type ConversationMessageWriteInput = {
+  threadId?: number;
+  role: ConversationMessageRecord["role"];
+  kind: ConversationMessageRecord["kind"];
+  content: string;
+  summary?: string | null;
+  linkedIssueNumber?: number | null;
+  linkedPrNumber?: number | null;
+  isOpenQuestion?: boolean;
+  workItemId?: number | null;
+  issueNumber?: number | null;
+  prNumber?: number | null;
+  decisionId?: number | null;
+  runId?: number | null;
+};
+
+async function appendConversationMessage(
+  session: ProjectSession,
+  input: ConversationMessageWriteInput
+): Promise<ConversationMessageRecord> {
+  const thread =
+    input.threadId !== undefined
+      ? mapConversationThreadRow(
+          assertPresent(
+            (
+              await session.db
+                .select()
+                .from(conversationThreadsTable)
+                .where(eq(conversationThreadsTable.id, input.threadId))
+                .limit(1)
+            )[0],
+            `Conversation thread ${input.threadId} was not found.`
+          )
+        )
+      : await ensureConversationThread(session);
+  const timestamp = nowIso();
+  const result = await session.db.insert(conversationMessagesTable).values({
+    threadId: thread.id,
+    projectId: session.project.id,
+    role: input.role,
+    kind: input.kind,
+    content: input.content,
+    summary: input.summary ?? summarizeText(input.content),
+    linkedIssueNumber: input.linkedIssueNumber ?? input.issueNumber ?? null,
+    linkedPrNumber: input.linkedPrNumber ?? input.prNumber ?? null,
+    isOpenQuestion: input.isOpenQuestion ?? input.kind === "cos_question",
+    workItemId: input.workItemId,
+    issueNumber: input.issueNumber,
+    prNumber: input.prNumber,
+    decisionId: input.decisionId,
+    runId: input.runId,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+
+  await session.db
+    .update(conversationThreadsTable)
+    .set({
+      updatedAt: timestamp
+    })
+    .where(eq(conversationThreadsTable.id, thread.id));
+
+  const row = await session.db
+    .select()
+    .from(conversationMessagesTable)
+    .where(eq(conversationMessagesTable.id, Number(result.lastInsertRowid)))
+    .limit(1);
+  return mapConversationMessageRow(assertPresent(row[0], "Conversation message missing after insert."));
+}
+
+async function getOpenHumanDecision(session: ProjectSession): Promise<DecisionRecord | null> {
+  const rows = await session.db
+    .select()
+    .from(decisionsTable)
+    .where(eq(decisionsTable.projectId, session.project.id));
+  return (
+    rows
+      .map(mapDecisionRow)
+      .filter((decision) => decision.status === "open" && decision.target === "human_director")
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+      .at(0) ?? null
+  );
+}
+
+function formatQuestionContentFromDecision(decision: DecisionRecord): string {
+  const prompt =
+    decision.issueNumber !== null
+      ? `I need your direction on issue #${decision.issueNumber} before I resume the work.`
+      : decision.title.trim() || "I need your direction before I can continue.";
+  const whyItMatters = decision.summary.trim()
+    ? `Why this matters: ${decision.summary.trim()}`
+    : null;
+  const recommendation = `Recommendation: ${
+    decision.recommendation.trim() || "Reply with the direction you want me to take."
+  }`;
+
+  return [prompt, whyItMatters, recommendation]
+    .filter((value): value is string => Boolean(value && value.trim().length > 0))
+    .join("\n\n");
+}
+
+async function backfillOpenDecisionQuestions(session: ProjectSession): Promise<void> {
+  const thread = await ensureConversationThread(session);
+  const rows = await session.db
+    .select()
+    .from(decisionsTable)
+    .where(eq(decisionsTable.projectId, session.project.id));
+  const openHumanDecisions = rows
+    .map(mapDecisionRow)
+    .filter((decision) => decision.status === "open" && decision.target === "human_director")
+    .filter((decision) => decision.questionMessageId === null)
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+
+  for (const decision of openHumanDecisions) {
+    const content = formatQuestionContentFromDecision(decision);
+    const questionMessage = await appendConversationMessage(session, {
+      threadId: thread.id,
+      role: "chief_of_staff",
+      kind: "cos_question",
+      content,
+      summary: summarizeText(content),
+      linkedIssueNumber: decision.issueNumber ?? null,
+      linkedPrNumber: decision.prNumber ?? null,
+      isOpenQuestion: true,
+      workItemId: decision.workItemId ?? null,
+      issueNumber: decision.issueNumber ?? null,
+      prNumber: decision.prNumber ?? null,
+      decisionId: decision.id,
+      runId: decision.requestedByRunId ?? null
+    });
+
+    await session.db
+      .update(decisionsTable)
+      .set({
+        questionMessageId: questionMessage.id,
+        updatedAt: nowIso()
+      })
+      .where(eq(decisionsTable.id, decision.id));
+  }
+}
+
+async function getConversationQuestionMessage(
+  session: ProjectSession,
+  decision: DecisionRecord | null
+): Promise<ConversationMessageRecord | null> {
+  if (!decision?.questionMessageId) {
+    return null;
+  }
+
+  const rows = await session.db
+    .select()
+    .from(conversationMessagesTable)
+    .where(eq(conversationMessagesTable.id, decision.questionMessageId))
+    .limit(1);
+
+  return rows[0] ? mapConversationMessageRow(rows[0]) : null;
+}
+
+async function getConversationResponse(session: ProjectSession): Promise<ConversationResponse> {
+  const thread = await ensureConversationThread(session);
+  await backfillOpenDecisionQuestions(session);
+  const messageRows = await session.db
+    .select()
+    .from(conversationMessagesTable)
+    .where(eq(conversationMessagesTable.threadId, thread.id));
+  const messages = messageRows
+    .map(mapConversationMessageRow)
+    .sort((left, right) =>
+      left.createdAt === right.createdAt ? left.id - right.id : left.createdAt.localeCompare(right.createdAt)
+    );
+  const openDecision = await getOpenHumanDecision(session);
+  const openQuestion =
+    (await getConversationQuestionMessage(session, openDecision)) ??
+    messages.find((message) => message.isOpenQuestion && message.kind === "cos_question") ??
+    null;
+
+  return {
+    thread,
+    messages,
+    openQuestion,
+    latestSummary: messages.at(-1)?.summary ?? null
+  };
+}
+
+function formatResolutionMessage(decision: DecisionRecord, resolution: string): string {
+  const lines = [
+    `Resolution recorded for: ${decision.title}`,
+    resolution.trim(),
+    decision.recommendation ? `Chief of Staff recommendation: ${decision.recommendation}` : null,
+    decision.summary ? `Context: ${decision.summary}` : null
+  ].filter((line): line is string => Boolean(line && line.trim().length > 0));
+
+  return lines.join("\n");
+}
+
 async function createDecision(
   session: ProjectSession,
   input: Omit<DecisionRecord, "id" | "projectId" | "createdAt" | "updatedAt" | "status" | "resolution">
@@ -1137,6 +1436,9 @@ async function createDecision(
     workItemId: input.workItemId,
     issueNumber: input.issueNumber,
     prNumber: input.prNumber,
+    requestedByRunId: input.requestedByRunId,
+    questionMessageId: input.questionMessageId,
+    resolutionMessageId: input.resolutionMessageId,
     target: input.target,
     title: input.title,
     summary: input.summary,
@@ -1532,6 +1834,243 @@ function parseDataArray(value: unknown): Array<Record<string, unknown>> {
     : [];
 }
 
+function guidancePromptSuffix(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (
+    value.startsWith("Decision resolved:") ||
+    value.startsWith("Chief of Staff guidance:") ||
+    value.startsWith("Human guidance:")
+  ) {
+    return value;
+  }
+
+  return undefined;
+}
+
+async function recentConversationPrompt(session: ProjectSession, limit = 10): Promise<string> {
+  const thread = await ensureConversationThread(session);
+  const rows = await session.db
+    .select()
+    .from(conversationMessagesTable)
+    .where(eq(conversationMessagesTable.threadId, thread.id));
+  const messages = rows
+    .map(mapConversationMessageRow)
+    .sort((left, right) =>
+      left.createdAt === right.createdAt ? left.id - right.id : left.createdAt.localeCompare(right.createdAt)
+    )
+    .slice(-limit);
+
+  if (!messages.length) {
+    return "No prior conversation.";
+  }
+
+  return messages
+    .map((message) => `[${message.role}/${message.kind}] ${message.content}`)
+    .join("\n");
+}
+
+async function createHumanQuestionDecision(
+  session: ProjectSession,
+  input: {
+    workItem: WorkItemRecord | null;
+    prNumber: number | null;
+    runId: number | null;
+    title: string;
+    summary: string;
+    question: string;
+    recommendation: string;
+    rationale: string;
+  }
+): Promise<DecisionRecord> {
+  const questionContent = [
+    input.question.trim(),
+    "",
+    `Why this matters: ${input.summary.trim()}`,
+    `Recommendation: ${input.recommendation.trim() || "Reply with the direction you want me to take."}`
+  ].join("\n");
+  const questionMessage = await appendConversationMessage(session, {
+    role: "chief_of_staff",
+    kind: "cos_question",
+    content: questionContent,
+    summary: summarizeText(questionContent),
+    linkedIssueNumber: input.workItem?.issueNumber ?? null,
+    linkedPrNumber: input.prNumber,
+    isOpenQuestion: true,
+    workItemId: input.workItem?.id ?? null,
+    issueNumber: input.workItem?.issueNumber ?? null,
+    prNumber: input.prNumber,
+    decisionId: null,
+    runId: input.runId
+  });
+
+  const decision = await createDecision(session, {
+    workItemId: input.workItem?.id ?? null,
+    issueNumber: input.workItem?.issueNumber ?? null,
+    prNumber: input.prNumber,
+    requestedByRunId: input.runId,
+    questionMessageId: questionMessage.id,
+    resolutionMessageId: null,
+    target: "human_director",
+    title: input.title,
+    summary: input.summary,
+    recommendation: input.recommendation,
+    rationale: input.rationale
+  });
+
+  await session.db
+    .update(conversationMessagesTable)
+    .set({
+      decisionId: decision.id,
+      isOpenQuestion: true,
+      updatedAt: nowIso()
+    })
+    .where(eq(conversationMessagesTable.id, questionMessage.id));
+
+  return decision;
+}
+
+async function mediateAgentBlock(
+  session: ProjectSession,
+  input: {
+    workItem: WorkItemRecord;
+    runId: number;
+    prNumber: number | null;
+    source: "lane_owner" | "worker";
+    summary: string;
+    recommendedNextAction: string;
+    blockingQuestions: string[];
+    allowInternalResolution: boolean;
+  }
+): Promise<
+  | { kind: "resume"; guidance: string; transcript: string }
+  | { kind: "ask_human"; decision: DecisionRecord }
+> {
+  if (!input.allowInternalResolution) {
+    const firstQuestion =
+      input.blockingQuestions[0] ??
+      "There is a blocking product decision that the Chief of Staff could not safely infer.";
+    const decision = await createHumanQuestionDecision(session, {
+      workItem: input.workItem,
+      prNumber: input.prNumber,
+      runId: input.runId,
+      title: `Chief of Staff question for #${input.workItem.issueNumber}`,
+      summary: input.summary,
+      question: firstQuestion,
+      recommendation: input.recommendedNextAction || "Reply with the direction you want me to take.",
+      rationale:
+        input.blockingQuestions.join("\n") ||
+        `${input.source} could not proceed safely without human product judgment.`
+    });
+    return {
+      kind: "ask_human",
+      decision
+    };
+  }
+
+  const result = await runCodexAgent(
+    {
+      role: "chief_of_staff",
+      cwd: session.project.repoPath,
+      model: session.project.model,
+      allowWrite: false,
+      prompt: [
+        `A ${input.source.replace("_", " ")} is blocked on issue #${input.workItem.issueNumber}: ${input.workItem.title}.`,
+        "Decide whether you can answer the blocker yourself or need to ask the human director.",
+        "Return `data.outcome` as `answer_worker` or `ask_human`.",
+        "If you can answer, return `data.guidance` and `data.transcript_reply`.",
+        "If you need the human, return `data.question`, `data.why_it_matters`, and `data.recommendation`.",
+        "",
+        "Current summary:",
+        input.summary,
+        "",
+        "Blocking questions:",
+        input.blockingQuestions.length ? input.blockingQuestions.map((question) => `- ${question}`).join("\n") : "- No explicit question was returned.",
+        "",
+        "Recent project conversation:",
+        await recentConversationPrompt(session)
+      ].join("\n")
+    },
+    {
+      status: "ok",
+      summary: input.summary,
+      recommended_next_action: input.recommendedNextAction,
+      artifact_refs: [],
+      blocking_questions: [],
+      data: {
+        outcome: "ask_human",
+        question:
+          input.blockingQuestions[0] ??
+          `What product decision should I take for issue #${input.workItem.issueNumber}?`,
+        why_it_matters: input.summary,
+        recommendation: input.recommendedNextAction
+      }
+    }
+  );
+
+  const outcome = parseDataString(result.data?.outcome);
+  if (outcome === "answer_worker") {
+    return {
+      kind: "resume",
+      guidance:
+        parseDataString(result.data?.guidance) ??
+        (input.blockingQuestions.join("\n") || input.recommendedNextAction),
+      transcript:
+        parseDataString(result.data?.transcript_reply) ??
+        `I answered the blocker for #${input.workItem.issueNumber} internally and resumed the work.`
+    };
+  }
+
+  const decision = await createHumanQuestionDecision(session, {
+    workItem: input.workItem,
+    prNumber: input.prNumber,
+    runId: input.runId,
+    title: `Chief of Staff question for #${input.workItem.issueNumber}`,
+    summary: parseDataString(result.data?.why_it_matters) ?? input.summary,
+    question:
+      parseDataString(result.data?.question) ??
+      input.blockingQuestions[0] ??
+      `What direction should I take for issue #${input.workItem.issueNumber}?`,
+    recommendation:
+      parseDataString(result.data?.recommendation) ??
+      (input.recommendedNextAction || "Reply with the direction you want me to take."),
+    rationale:
+      input.blockingQuestions.join("\n") ||
+      result.summary ||
+      `${input.source} could not proceed safely without human product judgment.`
+  });
+  return {
+    kind: "ask_human",
+    decision
+  };
+}
+
+async function appendCoSStatusUpdate(
+  session: ProjectSession,
+  input: {
+    content: string;
+    workItem: WorkItemRecord | null;
+    prNumber?: number | null;
+    runId?: number | null;
+    kind?: ConversationMessageRecord["kind"];
+  }
+): Promise<void> {
+  await appendConversationMessage(session, {
+    role: "chief_of_staff",
+    kind: input.kind ?? "status_update",
+    content: input.content,
+    summary: summarizeText(input.content),
+    workItemId: input.workItem?.id ?? null,
+    issueNumber: input.workItem?.issueNumber ?? null,
+    prNumber: input.prNumber ?? null,
+    decisionId: null,
+    runId: input.runId ?? null
+  });
+}
+
+
 async function chooseNextWorkItem(session: ProjectSession): Promise<WorkItemRecord | null> {
   const workItems = (
     await session.db
@@ -1807,7 +2346,10 @@ async function planLaneWork(session: ProjectSession, workItem: WorkItemRecord): 
         "If this should split into child issues, return them in `data.child_tasks` as objects with `title` and `body`.",
         "Only raise blocking questions when genuine product judgment is required.",
         "",
-        liveIssue.body
+        liveIssue.body,
+        guidancePromptSuffix(workItem.lastSummary)
+          ? `\nExisting guidance:\n${guidancePromptSuffix(workItem.lastSummary)}`
+          : ""
       ].join("\n")
     },
     {
@@ -1832,16 +2374,45 @@ async function planLaneWork(session: ProjectSession, workItem: WorkItemRecord): 
   });
 
   if (laneResult.blocking_questions.length > 0) {
-    await createDecision(session, {
-      workItemId: workItem.id,
-      issueNumber: workItem.issueNumber,
+    const mediated = await mediateAgentBlock(session, {
+      workItem,
+      runId: run.id,
       prNumber: null,
-      target: "human_director",
-      title: `Answer product questions for #${workItem.issueNumber}`,
+      source: "lane_owner",
       summary: laneResult.summary,
-      recommendation: laneResult.recommended_next_action,
-      rationale: laneResult.blocking_questions.join("\n")
+      recommendedNextAction: laneResult.recommended_next_action,
+      blockingQuestions: laneResult.blocking_questions,
+      allowInternalResolution: !guidancePromptSuffix(workItem.lastSummary)
     });
+
+    if (mediated.kind === "resume") {
+      await appendCoSStatusUpdate(session, {
+        content: mediated.transcript,
+        workItem,
+        runId: run.id
+      });
+      await upsertWorkItem(session.db, session.project.id, {
+        issueNumber: workItem.issueNumber,
+        parentIssueNumber: workItem.parentIssueNumber,
+        title: workItem.title,
+        summary: workItem.summary,
+        kind: "workstream",
+        executionMode: "lane",
+        ownerRole: "lane_owner",
+        status: "ready",
+        priorityBucket: inferPriorityBucket("ready"),
+        activeRunId: null,
+        activePrNumber: workItem.activePrNumber,
+        lastSummary: `Chief of Staff guidance: ${mediated.guidance}`
+      });
+      return planLaneWork(
+        session,
+        assertPresent(
+          await getWorkItemByIssueNumber(session.db, session.project.id, workItem.issueNumber),
+          `Work item #${workItem.issueNumber} disappeared during CoS mediation.`
+        )
+      );
+    }
 
     await upsertWorkItem(session.db, session.project.id, {
       issueNumber: workItem.issueNumber,
@@ -1989,7 +2560,9 @@ async function executeWorkerRun(
         "Leave the repository ready for commit.",
         "",
         options.issue.body,
-        options.promptSuffix ? `\nFollow-up context:\n${options.promptSuffix}` : ""
+        options.promptSuffix || guidancePromptSuffix(workItem.lastSummary)
+          ? `\nFollow-up context:\n${options.promptSuffix ?? guidancePromptSuffix(workItem.lastSummary)}`
+          : ""
       ].join("\n")
     },
     {
@@ -2011,16 +2584,51 @@ async function executeWorkerRun(
       outputJson: workerResult.data ?? null
     });
 
-    await createDecision(session, {
-      workItemId: workItem.id,
-      issueNumber: workItem.issueNumber,
+    const mediated = await mediateAgentBlock(session, {
+      workItem,
+      runId: run.id,
       prNumber: options.existingPrNumber ?? null,
-      target: "human_director",
-      title: `Clarify issue #${workItem.issueNumber}`,
+      source: "worker",
       summary: workerResult.summary,
-      recommendation: workerResult.recommended_next_action,
-      rationale: workerResult.blocking_questions.join("\n") || "Worker requested human clarification."
+      recommendedNextAction: workerResult.recommended_next_action,
+      blockingQuestions: workerResult.blocking_questions,
+      allowInternalResolution:
+        !options.promptSuffix && !guidancePromptSuffix(workItem.lastSummary)
     });
+
+    if (mediated.kind === "resume") {
+      await appendCoSStatusUpdate(session, {
+        content: mediated.transcript,
+        workItem,
+        prNumber: options.existingPrNumber ?? null,
+        runId: run.id
+      });
+      await upsertWorkItem(session.db, session.project.id, {
+        issueNumber: workItem.issueNumber,
+        parentIssueNumber: workItem.parentIssueNumber,
+        title: workItem.title,
+        summary: workItem.summary,
+        kind: workItem.kind,
+        executionMode: "worker",
+        ownerRole: "worker",
+        status: "ready",
+        priorityBucket: inferPriorityBucket("ready"),
+        activeRunId: null,
+        activePrNumber: options.existingPrNumber ?? workItem.activePrNumber,
+        lastSummary: `Chief of Staff guidance: ${mediated.guidance}`
+      });
+      return executeWorkerRun(
+        session,
+        assertPresent(
+          await getWorkItemByIssueNumber(session.db, session.project.id, workItem.issueNumber),
+          `Work item #${workItem.issueNumber} disappeared during CoS mediation.`
+        ),
+        {
+          ...options,
+          promptSuffix: mediated.guidance
+        }
+      );
+    }
 
     await upsertWorkItem(session.db, session.project.id, {
       issueNumber: workItem.issueNumber,
@@ -2176,6 +2784,12 @@ async function executeWorkerRun(
     prNumber: livePullRequest.number,
     prUrl: prUrl ?? livePullRequest.url
   });
+  await appendCoSStatusUpdate(session, {
+    content: `I opened PR #${livePullRequest.number} for issue #${workItem.issueNumber}: ${livePullRequest.title}.`,
+    workItem,
+    prNumber: livePullRequest.number,
+    runId: run.id
+  });
 }
 
 function latestUnhandledComment(
@@ -2217,6 +2831,7 @@ async function runCosReviewOnPr(
         "Decide whether to merge, request changes, or escalate to the human director.",
         "Return the verdict in `data.decision` as `merge`, `changes`, or `escalate`.",
         "If you choose `changes`, provide concise `data.feedback` that a worker can act on.",
+        "If you choose `escalate`, provide `data.question`, `data.why_it_matters`, and `data.recommendation`.",
         "",
         `Issue: ${workItem.title}`,
         "",
@@ -2284,14 +2899,19 @@ async function runCosReviewOnPr(
   }
 
   if (normalized === "escalate") {
-    await createDecision(session, {
-      workItemId: workItem.id,
-      issueNumber: workItem.issueNumber,
+    await createHumanQuestionDecision(session, {
+      workItem,
       prNumber: pr.number,
-      target: "human_director",
+      runId: null,
       title: `Resolve merge judgment for PR #${pr.number}`,
-      summary: result.summary,
-      recommendation: result.recommended_next_action,
+      summary: parseDataString(result.data?.why_it_matters) ?? result.summary,
+      question:
+        parseDataString(result.data?.question) ??
+        result.blocking_questions[0] ??
+        `Should I merge PR #${pr.number} for issue #${workItem.issueNumber}?`,
+      recommendation:
+        parseDataString(result.data?.recommendation) ??
+        result.recommended_next_action,
       rationale: result.blocking_questions.join("\n") || "Chief of Staff requested a human decision."
     });
   }
@@ -2447,13 +3067,13 @@ async function processPrCycles(session: ProjectSession): Promise<boolean> {
     }
 
     if (pullRequest.checksBucket === "fail") {
-      await createDecision(session, {
-        workItemId: workItem.id,
-        issueNumber: workItem.issueNumber,
+      await createHumanQuestionDecision(session, {
+        workItem,
         prNumber: pullRequest.number,
-        target: "human_director",
+        runId: null,
         title: `Investigate failing checks on PR #${pullRequest.number}`,
         summary: "Automated checks failed and need human judgment or a deeper fix.",
+        question: `PR #${pullRequest.number} failed automated checks. Should I keep iterating on this slice or narrow its scope?`,
         recommendation: "Inspect the failing GitHub checks and decide whether to retry or narrow scope.",
         rationale: "The current MVP does not yet fetch full CI logs for autonomous remediation."
       });
@@ -2508,6 +3128,11 @@ async function processPrCycles(session: ProjectSession): Promise<boolean> {
         activePrNumber: null,
         lastSummary: "Merged by Chief of Staff."
       });
+      await appendCoSStatusUpdate(session, {
+        content: `PR #${pullRequest.number} merged for issue #${workItem.issueNumber}.`,
+        workItem,
+        prNumber: pullRequest.number
+      });
     } else if (verdict === "escalate") {
       await upsertPrCycle(session.db, session.project.id, {
         issueNumber: cycle.issueNumber,
@@ -2543,14 +3168,14 @@ async function processNextQueueItem(session: ProjectSession): Promise<boolean> {
       .map(mapDecisionRow)
       .filter((decision) => decision.status === "open" && decision.title === "No queueable work remains");
     if (!openDecisions.length) {
-      await createDecision(session, {
-        workItemId: null,
-        issueNumber: null,
+      await createHumanQuestionDecision(session, {
+        workItem: null,
         prNumber: null,
-        target: "human_director",
+        runId: null,
         title: "No queueable work remains",
         summary: "The backlog is empty and the Chief of Staff could not expand any active notes.",
-        recommendation: "Add a new director note or create fresh GitHub issues.",
+        question: "I’m out of safe autonomous work. What product direction or slice should I take next?",
+        recommendation: "Reply in chat with the next direction, constraint, or GitHub issue to prioritize.",
         rationale: "Director OS ran out of safe autonomous work."
       });
     }
@@ -2573,7 +3198,8 @@ async function processNextQueueItem(session: ProjectSession): Promise<boolean> {
 
   await executeWorkerRun(session, next, {
     issue,
-    phase: "implementation"
+    phase: "implementation",
+    promptSuffix: guidancePromptSuffix(next.lastSummary)
   });
   return true;
 }
@@ -2603,13 +3229,13 @@ async function runOrchestratorIteration(): Promise<boolean> {
         lastLoopAt: nowIso(),
         lastSummary: message
       });
-      await createDecision(session, {
-        workItemId: null,
-        issueNumber: null,
+      await createHumanQuestionDecision(session, {
+        workItem: null,
         prNumber: null,
-        target: "human_director",
+        runId: null,
         title: "Orchestrator blocked",
         summary: message,
+        question: "The orchestrator hit an unexpected error and paused itself. What should I do next?",
         recommendation: "Inspect the latest run and local environment, then restart the orchestrator.",
         rationale: "The background loop hit an unexpected error."
       });
@@ -2907,6 +3533,258 @@ export async function listDecisions(): Promise<DecisionsResponse> {
   });
 }
 
+async function insertDirectorNoteRecord(
+  session: ProjectSession,
+  content: string
+): Promise<DirectorNoteRecord> {
+  const timestamp = nowIso();
+  const result = await session.db.insert(directorNotesTable).values({
+    projectId: session.project.id,
+    content,
+    status: "active",
+    createdAt: timestamp,
+    updatedAt: timestamp
+  });
+  await recordEvent(session.db, session.project.id, "director_note.created", {
+    content
+  });
+  const row = await session.db
+    .select()
+    .from(directorNotesTable)
+    .where(eq(directorNotesTable.id, Number(result.lastInsertRowid)))
+    .limit(1);
+  return mapNoteRow(assertPresent(row[0], "Director note missing after insert."));
+}
+
+type CoSChatReply = {
+  kind: "cos_reply" | "cos_question";
+  reply: string;
+  question: string | null;
+  recommendation: string | null;
+  rationale: string | null;
+};
+
+async function runCoSChatReply(
+  session: ProjectSession,
+  content: string
+): Promise<CoSChatReply> {
+  const result = await runCodexAgent(
+    {
+      role: "chief_of_staff",
+      cwd: session.project.repoPath,
+      model: session.project.model,
+      allowWrite: false,
+      prompt: [
+        "You are the Chief of Staff for Director OS.",
+        "Reply to the director's latest chat message in 1 to 3 concise sentences.",
+        "If the message is ambiguous, ask one short follow-up question.",
+        "Otherwise acknowledge the direction and say what you will do next.",
+        "Return `data.kind` as `cos_reply` or `cos_question`.",
+        "Return the human-facing reply in `data.reply`.",
+        "If you ask a question, also return `data.question` and `data.recommendation`.",
+        "",
+        "Recent conversation:",
+        await recentConversationPrompt(session),
+        "",
+        `Latest director message: ${content}`
+      ].join("\n")
+    },
+    {
+      status: "ok",
+      summary: "Noted. I’ll use that direction to steer prioritization and execution.",
+      recommended_next_action: "Continue running the current queue.",
+      artifact_refs: [],
+      blocking_questions: [],
+      data: {
+        kind: "cos_reply",
+        reply: "Noted. I’ll use that direction to steer prioritization and execution."
+      }
+    }
+  );
+
+  return {
+    kind: parseDataString(result.data?.kind) === "cos_question" ? "cos_question" : "cos_reply",
+    reply:
+      parseDataString(result.data?.reply) ??
+      result.summary ??
+      "Noted. I’ll use that direction to steer prioritization and execution.",
+    question: parseDataString(result.data?.question) ?? null,
+    recommendation: parseDataString(result.data?.recommendation) ?? null,
+    rationale: parseDataString(result.data?.rationale) ?? null
+  };
+}
+
+async function resolveDecisionInternal(
+  session: ProjectSession,
+  decisionId: number,
+  resolution: string
+): Promise<DecisionRecord> {
+  const rows = await session.db
+    .select()
+    .from(decisionsTable)
+    .where(eq(decisionsTable.id, decisionId))
+    .limit(1);
+  const row = assertPresent(rows[0], `Decision ${decisionId} was not found.`);
+
+  await session.db
+    .update(decisionsTable)
+    .set({
+      status: "resolved",
+      resolution,
+      updatedAt: nowIso()
+    })
+    .where(eq(decisionsTable.id, decisionId));
+
+  if (row.workItemId) {
+    const workItemRows = await session.db
+      .select()
+      .from(workItemsTable)
+      .where(eq(workItemsTable.id, row.workItemId))
+      .limit(1);
+    if (workItemRows[0]) {
+      const workItem = mapWorkItemRow(workItemRows[0]);
+      const resumedStatus: WorkItemStatus = workItem.activePrNumber ? "waiting_review" : "ready";
+      await upsertWorkItem(session.db, session.project.id, {
+        issueNumber: workItem.issueNumber,
+        parentIssueNumber: workItem.parentIssueNumber,
+        title: workItem.title,
+        summary: workItem.summary,
+        kind: workItem.kind,
+        executionMode: workItem.executionMode,
+        ownerRole: workItem.ownerRole,
+        status: resumedStatus,
+        priorityBucket: inferPriorityBucket(resumedStatus),
+        activeRunId: null,
+        activePrNumber: workItem.activePrNumber,
+        lastSummary: `Human guidance: ${resolution}`
+      });
+    }
+  }
+
+  if (row.questionMessageId) {
+    await session.db
+      .update(conversationMessagesTable)
+      .set({
+        isOpenQuestion: false,
+        decisionId,
+        updatedAt: nowIso()
+      })
+      .where(eq(conversationMessagesTable.id, row.questionMessageId));
+  }
+
+  const resolutionText = formatResolutionMessage(mapDecisionRow(row), resolution);
+  const resolutionMessage = await appendConversationMessage(session, {
+    role: "chief_of_staff",
+    kind: "resolution",
+    content: resolutionText,
+    summary: summarizeText(resolutionText),
+    linkedIssueNumber: row.issueNumber ?? null,
+    linkedPrNumber: row.prNumber ?? null,
+    isOpenQuestion: false,
+    workItemId: row.workItemId ?? null,
+    issueNumber: row.issueNumber ?? null,
+    prNumber: row.prNumber ?? null,
+    decisionId,
+    runId: row.requestedByRunId ?? null
+  });
+
+  await session.db
+    .update(decisionsTable)
+    .set({
+      resolutionMessageId: resolutionMessage.id,
+      updatedAt: nowIso()
+    })
+    .where(eq(decisionsTable.id, decisionId));
+
+  await recordEvent(session.db, session.project.id, "decision.resolved", {
+    decisionId,
+    resolution
+  });
+
+  const updatedRows = await session.db
+    .select()
+    .from(decisionsTable)
+    .where(eq(decisionsTable.id, decisionId))
+    .limit(1);
+  return mapDecisionRow(
+    assertPresent(updatedRows[0], `Decision ${decisionId} vanished after update.`)
+  );
+}
+
+export async function getConversation(): Promise<ConversationResponse> {
+  return withProject(async (session) => getConversationResponse(session));
+}
+
+export async function sendConversationMessage(
+  content: string
+): Promise<ConversationResponse> {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error("Message cannot be empty.");
+  }
+
+  return withProject(async (session) => {
+    await backfillOpenDecisionQuestions(session);
+    const openDecision = await getOpenHumanDecision(session);
+    if (openDecision) {
+      await appendConversationMessage(session, {
+        role: "director",
+        kind: "human_message",
+        content: trimmed,
+        summary: summarizeText(trimmed),
+        linkedIssueNumber: openDecision.issueNumber ?? null,
+        linkedPrNumber: openDecision.prNumber ?? null,
+        isOpenQuestion: false,
+        workItemId: openDecision.workItemId ?? null,
+        issueNumber: openDecision.issueNumber ?? null,
+        prNumber: openDecision.prNumber ?? null,
+        decisionId: openDecision.id,
+        runId: null
+      });
+      await resolveDecisionInternal(session, openDecision.id, trimmed);
+    } else {
+      await insertDirectorNoteRecord(session, trimmed);
+      const reply = await runCoSChatReply(session, trimmed);
+
+      if (reply.kind === "cos_question") {
+        await createHumanQuestionDecision(session, {
+          workItem: null,
+          prNumber: null,
+          runId: null,
+          title: "Chief of Staff question",
+          summary: reply.reply,
+          question:
+            reply.question ?? "I need a little more direction before I can continue.",
+          recommendation:
+            reply.recommendation ?? "Reply here with the direction you want me to take.",
+          rationale: reply.rationale ?? reply.reply
+        });
+      } else {
+        await appendConversationMessage(session, {
+          role: "chief_of_staff",
+          kind: "cos_reply",
+          content: reply.reply,
+          summary: summarizeText(reply.reply),
+          linkedIssueNumber: null,
+          linkedPrNumber: null,
+          isOpenQuestion: false,
+          workItemId: null,
+          issueNumber: null,
+          prNumber: null,
+          decisionId: null,
+          runId: null
+        });
+      }
+    }
+
+    const orchestrator = await ensureOrchestratorRow(session);
+    if (orchestrator.status === "running" && !orchestratorTimer && !orchestratorRunning) {
+      scheduleOrchestratorLoop(0);
+    }
+    return getConversationResponse(session);
+  });
+}
+
 export async function submitDirectorNote(content: string): Promise<DirectorNoteRecord> {
   const trimmed = content.trim();
   if (!trimmed) {
@@ -2914,23 +3792,21 @@ export async function submitDirectorNote(content: string): Promise<DirectorNoteR
   }
 
   return withProject(async (session) => {
-    const timestamp = nowIso();
-    const result = await session.db.insert(directorNotesTable).values({
-      projectId: session.project.id,
+    const note = await insertDirectorNoteRecord(session, trimmed);
+    await appendConversationMessage(session, {
+      role: "director",
+      kind: "human_message",
       content: trimmed,
-      status: "active",
-      createdAt: timestamp,
-      updatedAt: timestamp
+      summary: summarizeText(trimmed),
+      linkedIssueNumber: null,
+      linkedPrNumber: null,
+      isOpenQuestion: false,
+      workItemId: null,
+      issueNumber: null,
+      prNumber: null,
+      decisionId: null,
+      runId: null
     });
-    await recordEvent(session.db, session.project.id, "director_note.created", {
-      content: trimmed
-    });
-    const row = await session.db
-      .select()
-      .from(directorNotesTable)
-      .where(eq(directorNotesTable.id, Number(result.lastInsertRowid)))
-      .limit(1);
-    const note = mapNoteRow(assertPresent(row[0], "Director note missing after insert."));
     const orchestrator = await ensureOrchestratorRow(session);
     if (orchestrator.status === "running" && !orchestratorTimer && !orchestratorRunning) {
       scheduleOrchestratorLoop(0);
@@ -2949,59 +3825,7 @@ export async function resolveDecision(
   }
 
   return withProject(async (session) => {
-    const rows = await session.db
-      .select()
-      .from(decisionsTable)
-      .where(eq(decisionsTable.id, decisionId))
-      .limit(1);
-    const row = assertPresent(rows[0], `Decision ${decisionId} was not found.`);
-
-    await session.db
-      .update(decisionsTable)
-      .set({
-        status: "resolved",
-        resolution: trimmed,
-        updatedAt: nowIso()
-      })
-      .where(eq(decisionsTable.id, decisionId));
-
-    if (row.workItemId) {
-      const workItemRows = await session.db
-        .select()
-        .from(workItemsTable)
-        .where(eq(workItemsTable.id, row.workItemId))
-        .limit(1);
-      if (workItemRows[0]) {
-        const workItem = mapWorkItemRow(workItemRows[0]);
-        const resumedStatus: WorkItemStatus = workItem.activePrNumber ? "waiting_review" : "ready";
-        await upsertWorkItem(session.db, session.project.id, {
-          issueNumber: workItem.issueNumber,
-          parentIssueNumber: workItem.parentIssueNumber,
-          title: workItem.title,
-          summary: workItem.summary,
-          kind: workItem.kind,
-          executionMode: workItem.executionMode,
-          ownerRole: workItem.ownerRole,
-          status: resumedStatus,
-          priorityBucket: inferPriorityBucket(resumedStatus),
-          activeRunId: null,
-          activePrNumber: workItem.activePrNumber,
-          lastSummary: `Decision resolved: ${trimmed}`
-        });
-      }
-    }
-
-    await recordEvent(session.db, session.project.id, "decision.resolved", {
-      decisionId,
-      resolution: trimmed
-    });
-
-    const updatedRows = await session.db
-      .select()
-      .from(decisionsTable)
-      .where(eq(decisionsTable.id, decisionId))
-      .limit(1);
-    const decision = mapDecisionRow(assertPresent(updatedRows[0], `Decision ${decisionId} vanished after update.`));
+    const decision = await resolveDecisionInternal(session, decisionId, trimmed);
 
     const orchestrator = await ensureOrchestratorRow(session);
     if (orchestrator.status === "running" && !orchestratorTimer && !orchestratorRunning) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,14 @@ export const DECISION_TARGETS = ["chief_of_staff", "human_director"] as const;
 export const DECISION_STATUSES = ["open", "resolved", "dismissed"] as const;
 export const ORCHESTRATOR_STATUSES = ["idle", "running", "paused", "blocked"] as const;
 export const NOTE_STATUSES = ["active", "archived"] as const;
+export const CONVERSATION_MESSAGE_ROLES = ["director", "chief_of_staff", "system"] as const;
+export const CONVERSATION_MESSAGE_KINDS = [
+  "human_message",
+  "cos_reply",
+  "cos_question",
+  "status_update",
+  "resolution"
+] as const;
 export const PR_CYCLE_STATUSES = [
   "opened",
   "waiting_automation",
@@ -77,6 +85,8 @@ export type DecisionTarget = (typeof DECISION_TARGETS)[number];
 export type DecisionStatus = (typeof DECISION_STATUSES)[number];
 export type OrchestratorStatus = (typeof ORCHESTRATOR_STATUSES)[number];
 export type NoteStatus = (typeof NOTE_STATUSES)[number];
+export type ConversationMessageRole = (typeof CONVERSATION_MESSAGE_ROLES)[number];
+export type ConversationMessageKind = (typeof CONVERSATION_MESSAGE_KINDS)[number];
 export type PrCycleStatus = (typeof PR_CYCLE_STATUSES)[number];
 export type SetupCheckKind = (typeof SETUP_CHECK_KINDS)[number];
 export type SetupCheckStatus = (typeof SETUP_CHECK_STATUSES)[number];
@@ -174,6 +184,9 @@ export interface DecisionRecord {
   workItemId: number | null;
   issueNumber: number | null;
   prNumber: number | null;
+  requestedByRunId: number | null;
+  questionMessageId: number | null;
+  resolutionMessageId: number | null;
   target: DecisionTarget;
   title: string;
   summary: string;
@@ -190,6 +203,30 @@ export interface DirectorNoteRecord {
   projectId: number;
   content: string;
   status: NoteStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConversationThreadRecord {
+  id: number;
+  projectId: number;
+  title: string;
+  status: "active" | "archived";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConversationMessageRecord {
+  id: number;
+  projectId: number;
+  threadId: number;
+  role: ConversationMessageRole;
+  kind: ConversationMessageKind;
+  content: string;
+  summary: string | null;
+  linkedIssueNumber: number | null;
+  linkedPrNumber: number | null;
+  isOpenQuestion: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -277,6 +314,13 @@ export interface DirectorStatusResponse {
   openPullRequests: GitHubPullRequestRecord[];
 }
 
+export interface ConversationResponse {
+  thread: ConversationThreadRecord | null;
+  messages: ConversationMessageRecord[];
+  openQuestion: ConversationMessageRecord | null;
+  latestSummary: string | null;
+}
+
 export interface DecisionsResponse {
   decisions: DecisionRecord[];
 }
@@ -292,6 +336,8 @@ export interface DirectorClient {
   probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;
   runWorkspaceTest(repositoryDraft: SetupRepositoryDraft): Promise<SetupStatusResponse>;
   completeSetup(repositoryDraft: SetupRepositoryDraft): Promise<SetupStatusResponse>;
+  getConversation(): Promise<ConversationResponse>;
+  sendMessage(content: string): Promise<ConversationResponse>;
   getStatus(): Promise<DirectorStatusResponse>;
   start(): Promise<DirectorOperationResponse>;
   pause(reason?: string): Promise<DirectorOperationResponse>;
@@ -302,6 +348,10 @@ export interface DirectorClient {
 }
 
 export interface DirectorDesktopBridge {
+  conversation: {
+    getConversation(): Promise<ConversationResponse>;
+    sendMessage(content: string): Promise<ConversationResponse>;
+  };
   setup: {
     getStatus(): Promise<SetupStatusResponse>;
     probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;


### PR DESCRIPTION
Closes #31
Refs #24

## Summary
- make the desktop app chat-first, with the Chief of Staff conversation as the primary surface and the control room moved to a secondary sidebar
- add persistent conversation threads/messages plus CoS-mediated escalation plumbing so workers ask the CoS first and human-facing questions become explicit CoS-authored chat messages
- add conversation CLI/server/desktop bridge support and align the README with the new chat-first operating model

## Verification
- npm run typecheck
- npm run build
- npm run director -- status
- npm run director -- conversation
- npm run desktop:start
