### PR TITLE
Stabilize worker recovery and orchestrator ownership

### DIFF
--- a/packages/core/src/git-worktrees.test.ts
+++ b/packages/core/src/git-worktrees.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseGitWorktreeList,
+  selectReusableGitWorktree
+} from "./git-worktrees.js";
+
+describe("parseGitWorktreeList", () => {
+  it("parses branch and prunable flags from porcelain output", () => {
+    const parsed = parseGitWorktreeList(`
+worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /tmp/issue-30
+HEAD def456
+branch refs/heads/codex/issue-30
+prunable gitdir file points to non-existent location
+`);
+
+    expect(parsed).toEqual([
+      {
+        path: "/repo",
+        branchName: "main",
+        isPrunable: false
+      },
+      {
+        path: "/tmp/issue-30",
+        branchName: "codex/issue-30",
+        isPrunable: true
+      }
+    ]);
+  });
+});
+
+describe("selectReusableGitWorktree", () => {
+  it("prefers an exact live path match", () => {
+    const reusable = selectReusableGitWorktree(
+      [
+        {
+          path: "/tmp/issue-30",
+          branchName: "codex/issue-30-old-title",
+          isPrunable: false
+        },
+        {
+          path: "/tmp/elsewhere",
+          branchName: "codex/issue-30-new-title",
+          isPrunable: false
+        }
+      ],
+      "/tmp/issue-30",
+      "codex/issue-30-new-title"
+    );
+
+    expect(reusable).toEqual({
+      path: "/tmp/issue-30",
+      branchName: "codex/issue-30-old-title",
+      isPrunable: false
+    });
+  });
+
+  it("falls back to a live branch match when the desired path is unavailable", () => {
+    const reusable = selectReusableGitWorktree(
+      [
+        {
+          path: "/tmp/elsewhere",
+          branchName: "codex/issue-30",
+          isPrunable: false
+        },
+        {
+          path: "/tmp/prunable",
+          branchName: "codex/issue-30",
+          isPrunable: true
+        }
+      ],
+      "/tmp/issue-30",
+      "codex/issue-30"
+    );
+
+    expect(reusable).toEqual({
+      path: "/tmp/elsewhere",
+      branchName: "codex/issue-30",
+      isPrunable: false
+    });
+  });
+});

--- a/packages/core/src/git-worktrees.ts
+++ b/packages/core/src/git-worktrees.ts
@@ -1,0 +1,69 @@
+export type GitWorktreeEntry = {
+  path: string;
+  branchName: string | null;
+  isPrunable: boolean;
+};
+
+export function parseGitWorktreeList(porcelain: string): GitWorktreeEntry[] {
+  return porcelain
+    .trim()
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      let worktreePath: string | null = null;
+      let branchName: string | null = null;
+      let isPrunable = false;
+
+      for (const line of block.split("\n")) {
+        if (line.startsWith("worktree ")) {
+          worktreePath = line.slice("worktree ".length);
+          continue;
+        }
+
+        if (line.startsWith("branch ")) {
+          const rawBranch = line.slice("branch ".length);
+          branchName = rawBranch.startsWith("refs/heads/")
+            ? rawBranch.slice("refs/heads/".length)
+            : rawBranch;
+          continue;
+        }
+
+        if (line.startsWith("prunable")) {
+          isPrunable = true;
+        }
+      }
+
+      if (!worktreePath) {
+        return null;
+      }
+
+      return {
+        path: worktreePath,
+        branchName,
+        isPrunable
+      };
+    })
+    .filter((entry): entry is GitWorktreeEntry => entry !== null);
+}
+
+export function selectReusableGitWorktree(
+  entries: GitWorktreeEntry[],
+  desiredPath: string,
+  desiredBranchName: string
+): GitWorktreeEntry | null {
+  const exactPathMatch =
+    entries.find(
+      (entry) => entry.path === desiredPath && !entry.isPrunable && Boolean(entry.branchName)
+    ) ?? null;
+
+  if (exactPathMatch) {
+    return exactPathMatch;
+  }
+
+  return (
+    entries.find(
+      (entry) => entry.branchName === desiredBranchName && !entry.isPrunable && Boolean(entry.branchName)
+    ) ?? null
+  );
+}

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -91,6 +91,10 @@ import {
   viewPullRequest
 } from "./github.js";
 import {
+  parseGitWorktreeList,
+  selectReusableGitWorktree
+} from "./git-worktrees.js";
+import {
   inferWorkItemStatus,
   selectActiveWorkItems,
   selectQueuedWorkItems
@@ -135,6 +139,29 @@ async function runCommand(command: string, args: string[], cwd: string): Promise
   });
 
   return result.stdout.trim();
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listGitWorktrees(repoPath: string) {
+  const porcelain = await runCommand(
+    "git",
+    ["-C", repoPath, "worktree", "list", "--porcelain"],
+    repoPath
+  );
+
+  return parseGitWorktreeList(porcelain);
+}
+
+async function pruneGitWorktrees(repoPath: string): Promise<void> {
+  await runCommand("git", ["-C", repoPath, "worktree", "prune"], repoPath);
 }
 
 async function withRuntime<TValue>(
@@ -902,19 +929,37 @@ async function ensureWorktree(
   issueNumber: number,
   branchName: string,
   worktreePath: string
-): Promise<void> {
+): Promise<{ branchName: string; worktreePath: string }> {
   await fs.mkdir(project.worktreeRoot, { recursive: true });
+  await pruneGitWorktrees(project.repoPath);
 
-  try {
-    await fs.access(worktreePath);
-    return;
-  } catch {
-    await runCommand(
-      "git",
-      ["-C", project.repoPath, "worktree", "add", "-B", branchName, worktreePath, project.defaultBranch],
-      project.repoPath
-    );
+  const reusable = selectReusableGitWorktree(
+    await listGitWorktrees(project.repoPath),
+    worktreePath,
+    branchName
+  );
+
+  if (reusable && (await pathExists(reusable.path))) {
+    return {
+      branchName: reusable.branchName ?? branchName,
+      worktreePath: reusable.path
+    };
   }
+
+  if (await pathExists(worktreePath)) {
+    await fs.rm(worktreePath, { recursive: true, force: true });
+  }
+
+  await runCommand(
+    "git",
+    ["-C", project.repoPath, "worktree", "add", "-B", branchName, worktreePath, project.defaultBranch],
+    project.repoPath
+  );
+
+  return {
+    branchName,
+    worktreePath
+  };
 }
 
 async function upsertGitHubIssueMirror(
@@ -2589,9 +2634,15 @@ async function executeWorkerRun(
   const branchName =
     options.existingHeadRefName ??
     `codex/issue-${workItem.issueNumber}-${slugify(workItem.title).slice(0, 36)}`;
-  const worktreePath = path.join(session.project.worktreeRoot, `issue-${workItem.issueNumber}`);
-
-  await ensureWorktree(session.project, workItem.issueNumber, branchName, worktreePath);
+  const desiredWorktreePath = path.join(session.project.worktreeRoot, `issue-${workItem.issueNumber}`);
+  const ensuredWorktree = await ensureWorktree(
+    session.project,
+    workItem.issueNumber,
+    branchName,
+    desiredWorktreePath
+  );
+  const worktreePath = ensuredWorktree.worktreePath;
+  const activeBranchName = ensuredWorktree.branchName;
 
   const existingWorktreeRows = await session.db
     .select()
@@ -2604,7 +2655,7 @@ async function executeWorkerRun(
       .update(worktreesTable)
       .set({
         issueNumber: workItem.issueNumber,
-        branchName,
+        branchName: activeBranchName,
         status: "active",
         updatedAt: timestamp
       })
@@ -2613,7 +2664,7 @@ async function executeWorkerRun(
     await session.db.insert(worktreesTable).values({
       projectId: session.project.id,
       issueNumber: workItem.issueNumber,
-      branchName,
+      branchName: activeBranchName,
       path: worktreePath,
       status: "active",
       createdAt: timestamp,
@@ -2821,7 +2872,7 @@ async function executeWorkerRun(
     ["commit", "-m", `${options.existingPrNumber ? "Refine" : "Implement"} #${workItem.issueNumber}: ${workItem.title}`],
     worktreePath
   );
-  await runCommand("git", ["push", "-u", "origin", branchName], worktreePath);
+  await runCommand("git", ["push", "-u", "origin", activeBranchName], worktreePath);
 
   let prNumber = options.existingPrNumber ?? null;
   let prUrl: string | null = null;
@@ -2829,7 +2880,7 @@ async function executeWorkerRun(
   if (!prNumber) {
     const createdPullRequest = await createPullRequest(worktreePath, {
       baseBranch: session.project.defaultBranch,
-      headBranch: branchName,
+      headBranch: activeBranchName,
       title: workItem.title,
       body: [`Fixes #${workItem.issueNumber}`, "", workerResult.summary].join("\n")
     });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -11,6 +11,7 @@
     "src/cos.ts",
     "src/commands.ts",
     "src/db.ts",
+    "src/git-worktrees.ts",
     "src/github.ts",
     "src/index.ts",
     "src/server.ts",


### PR DESCRIPTION
Fixes #46
Fixes #48
Fixes #49

## Summary
- prune stale Git worktree metadata before claiming or recreating an issue worktree
- fix the Codex structured-output schema so worker runs can return parsed results instead of falling back to vague `needs_input` errors
- persist command-error detail in worker results and reuse a single open human-facing CoS question instead of creating duplicates for the same issue
- add a single local orchestrator owner lock plus interrupted-run recovery so multiple local Director OS processes do not keep reclaiming the same issue

## Verification
- npm run typecheck
- npm run build
- manual `codex exec` reproduction of the schema error, then confirmation that the updated schema returns structured JSON
- ps inspection to confirm stale `start` / `codex exec` processes were the source of duplicate local owners during dogfooding
- runtime smoke checks with `node apps/cli/dist/index.js status` and `node apps/cli/dist/index.js start`
