### PR TITLE
Simplify Director OS around CoS chat and lane visibility

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,7 +15,7 @@ import {
   syncProject
 } from "@director-os/core";
 
-program.name("director").description("Director OS local control plane").version("0.1.0");
+program.name("director").description("Director OS Chief of Staff chat plus lane visibility").version("0.1.0");
 
 program
   .command("init")
@@ -81,9 +81,24 @@ program
 
 program
   .command("status")
-  .description("Print the current control-room status payload")
+  .description("Print the current Chief of Staff and lane status payload")
   .action(async () => {
     console.log(JSON.stringify(await getDirectorStatus(), null, 2));
+  });
+
+program
+  .command("lanes")
+  .description("Print the current lane ownership view")
+  .action(async () => {
+    const status = await getDirectorStatus();
+    console.log(JSON.stringify({
+      orchestrator: status.orchestrator,
+      lastSuccessfulSyncAt: status.lastSuccessfulSyncAt,
+      openQuestion: status.openQuestion,
+      lanes: status.lanes,
+      issues: status.issues,
+      openPullRequests: status.openPullRequests
+    }, null, 2));
   });
 
 program
@@ -112,26 +127,26 @@ program
 
 program
   .command("submit-note")
-  .description("Debug alias for `message`")
+  .description("[debug] Alias for `message`")
   .argument("<content...>", "The note or product direction")
-  .action(async (contentParts) => {
+  .action(async (contentParts: string[]) => {
     const result = await sendConversationMessage(contentParts.join(" "));
     console.log(JSON.stringify(result, null, 2));
   });
 
 program
   .command("list-decisions")
-  .description("Debug view of open escalation decisions")
+  .description("[debug] View open escalation decisions")
   .action(async () => {
     console.log(JSON.stringify(await listDecisions(), null, 2));
   });
 
 program
   .command("resolve-decision")
-  .description("Debug path to resolve an escalation decision and resume work when appropriate")
+  .description("[debug] Resolve an escalation decision and resume work")
   .argument("<decisionId>", "Local decision id")
   .argument("<resolution...>", "Resolution text")
-  .action(async (decisionId, resolutionParts) => {
+  .action(async (decisionId: string, resolutionParts: string[]) => {
     const result = await resolveDecision(String(decisionId), resolutionParts.join(" "));
     console.log(JSON.stringify(result, null, 2));
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -71,9 +71,12 @@ export function App() {
 
   const counts = useMemo(
     () => ({
-      queued: status?.queue?.length ?? 0,
-      active: status?.activeWork?.length ?? 0,
-      decisions: status?.decisions?.length ?? 0,
+      lanes: status?.lanes.length ?? 0,
+      ownedIssues:
+        status?.issues.filter((issue) => issue.state.toLowerCase() === "open" && issue.laneId).length ?? 0,
+      blockers:
+        (status?.openQuestion ? 1 : 0) +
+        (status?.lanes.filter((lane) => lane.status === "blocked").length ?? 0),
       prs: status?.openPullRequests.length ?? 0
     }),
     [status]
@@ -414,33 +417,33 @@ export function App() {
             <div className="panel-header">
               <div>
                 <div className="section-title">State</div>
-                <div className="section-meta">{status?.orchestrator?.lastSummary ?? "The control room is ready."}</div>
+                <div className="section-meta">{status?.orchestrator?.lastSummary ?? "The Chief of Staff router is ready."}</div>
               </div>
             </div>
             <div className="hero-stats sidebar-stats">
-              <StatCard label="Queue" value={String(counts.queued)} />
-              <StatCard label="Running" value={String(counts.active)} />
-              <StatCard label="Waiting for you" value={String(counts.decisions)} />
+              <StatCard label="Lanes" value={String(counts.lanes)} />
+              <StatCard label="Owned issues" value={String(counts.ownedIssues)} />
+              <StatCard label="Blockers" value={String(counts.blockers)} />
               <StatCard label="Open PRs" value={String(counts.prs)} />
             </div>
             <div className="hero-meta">
               <span className={`status-pill status-pill-${(status?.orchestrator?.status ?? "idle").replace("_", "-")}`}>
                 {formatOrchestratorStatus(status?.orchestrator?.status ?? "idle")}
               </span>
-              <span>The Chief of Staff loop stays local and synchronized with GitHub.</span>
+              <span>The Chief of Staff loop stays local and routes work through persistent lane sessions.</span>
             </div>
           </section>
 
           <section className="panel sidebar-card">
             <div className="panel-header">
               <div>
-                <div className="section-title">Needs your judgment</div>
-                <div className="section-meta">Questions the CoS could not safely answer without you.</div>
+                <div className="section-title">Current blocker</div>
+                <div className="section-meta">Only the Chief of Staff escalates to you when a real product call is needed.</div>
               </div>
             </div>
-            <ItemList<NonNullable<DirectorStatusResponse["decisions"]>[number]>
-              empty="No human escalations are waiting right now."
-              items={status?.decisions ?? []}
+            <ItemList<NonNullable<DirectorStatusResponse["openQuestion"]>>
+              empty="No blocker is waiting on you right now."
+              items={status?.openQuestion ? [status.openQuestion] : []}
               render={(decision) => (
                 <div className="compact-card" key={decision.id}>
                   <div className="compact-card-head">
@@ -462,23 +465,24 @@ export function App() {
           <section className="panel sidebar-card">
             <div className="panel-header">
               <div>
-                <div className="section-title">Queue</div>
-                <div className="section-meta">GitHub remains the durable backlog behind the chat.</div>
+                <div className="section-title">Lanes</div>
+                <div className="section-meta">Persistent Codex sessions owned by the Chief of Staff.</div>
               </div>
             </div>
-            <ItemList<WorkItemRecord>
-              empty="No queueable work yet."
-              items={status?.queue ?? []}
-              render={(item) => (
-                <div className="list-row compact-list-row" key={item.id}>
+            <ItemList<DirectorStatusResponse["lanes"][number]>
+              empty="No lane sessions are active yet."
+              items={status?.lanes ?? []}
+              render={(lane) => (
+                <div className="list-row compact-list-row" key={lane.id}>
                   <div>
-                    <div className="list-title">#{item.issueNumber} {item.title}</div>
+                    <div className="list-title">{lane.name}</div>
                     <div className="list-meta">
-                      <span>{formatWorkItemStatus(item.status)}</span>
-                      {item.parentIssueNumber ? <span>From #{item.parentIssueNumber}</span> : null}
+                      <span>{String(lane.status).replace("_", " ")}</span>
+                      {lane.currentIssueNumber ? <span>Issue #{lane.currentIssueNumber}</span> : null}
+                      {lane.activePullRequestNumber ? <span>PR #{lane.activePullRequestNumber}</span> : null}
                     </div>
                   </div>
-                  <div className="list-note">{item.lastSummary ?? item.summary}</div>
+                  <div className="list-note">{lane.lastSummary ?? lane.lastPlanSummary ?? "Waiting for a routed issue."}</div>
                 </div>
               )}
             />
@@ -487,23 +491,24 @@ export function App() {
           <section className="panel sidebar-card">
             <div className="panel-header">
               <div>
-                <div className="section-title">In progress</div>
-                <div className="section-meta">What the CoS and Codex are actively moving right now.</div>
+                <div className="section-title">Lane-owned issues</div>
+                <div className="section-meta">GitHub issues stay durable; the router only shows who currently owns each slice.</div>
               </div>
             </div>
-            <ItemList<WorkItemRecord>
-              empty="Nothing is active right now."
-              items={status?.activeWork ?? []}
-              render={(item) => (
-                <div className="list-row compact-list-row" key={item.id}>
+            <ItemList<DirectorStatusResponse["issues"][number]>
+              empty="No GitHub issues are currently routed to lanes."
+              items={(status?.issues ?? []).filter((issue) => issue.state.toLowerCase() === "open" && issue.laneId)}
+              render={(issue) => (
+                <div className="list-row compact-list-row" key={issue.issueNumber}>
                   <div>
-                    <div className="list-title">#{item.issueNumber} {item.title}</div>
+                    <div className="list-title">#{issue.issueNumber} {issue.title}</div>
                     <div className="list-meta">
-                      <span>{formatWorkItemStatus(item.status)}</span>
-                      {item.activePrNumber ? <span>PR #{item.activePrNumber}</span> : null}
+                      {issue.laneName ? <span>{issue.laneName}</span> : null}
+                      <span>{String(issue.status).replace("_", " ")}</span>
+                      {issue.linkedPullRequestNumber ? <span>PR #{issue.linkedPullRequestNumber}</span> : null}
                     </div>
                   </div>
-                  <div className="list-note">{item.lastSummary ?? item.summary}</div>
+                  <div className="list-note">{issue.lastSummary ?? issue.workflowState}</div>
                 </div>
               )}
             />
@@ -513,22 +518,22 @@ export function App() {
             <div className="panel-header">
               <div>
                 <div className="section-title">Pull requests</div>
-                <div className="section-meta">Automation waits, review follow-up, and merge readiness.</div>
+                <div className="section-meta">Linked PRs stay visible, but they are downstream of CoS and lane routing.</div>
               </div>
             </div>
-            <ItemList<PrCycleRecord>
-              empty="No open PR cycles yet."
-              items={status?.prCycles ?? []}
-              render={(cycle) => (
-                <div className="list-row compact-list-row" key={cycle.id}>
+            <ItemList<DirectorStatusResponse["openPullRequests"][number]>
+              empty="No open pull requests yet."
+              items={status?.openPullRequests ?? []}
+              render={(pullRequest) => (
+                <div className="list-row compact-list-row" key={pullRequest.id}>
                   <div>
-                    <div className="list-title">PR #{cycle.prNumber} for issue #{cycle.issueNumber}</div>
+                    <div className="list-title">PR #{pullRequest.number} {pullRequest.title}</div>
                     <div className="list-meta">
-                      <span>{formatPrCycleStatus(cycle.status)}</span>
-                      {cycle.automationWindowEndsAt ? <span>Window ends {formatTimestamp(cycle.automationWindowEndsAt)}</span> : null}
+                      <span>{pullRequest.reviewDecision ?? (pullRequest.isDraft ? "Draft" : "Open")}</span>
+                      {pullRequest.linkedIssueNumbers[0] ? <span>Issue #{pullRequest.linkedIssueNumbers[0]}</span> : null}
                     </div>
                   </div>
-                  <div className="list-note">{cycle.summary}</div>
+                  <div className="list-note">{pullRequest.headRefName} {" -> "} {pullRequest.baseRefName}</div>
                 </div>
               )}
             />
@@ -537,27 +542,24 @@ export function App() {
           <section className="panel sidebar-card">
             <div className="panel-header">
               <div>
-                <div className="section-title">Recent runs</div>
-                <div className="section-meta">
-                  Chief of Staff, implementation, and review runs. Expand a run to inspect the stored output.
-                </div>
+                <div className="section-title">Recent activity</div>
+                <div className="section-meta">A lightweight trail of CoS and lane movement without exposing the old workflow engine.</div>
               </div>
             </div>
-            <ItemList<RunRecord>
-              empty="No runs recorded yet."
-              items={status?.recentRuns ?? []}
-              render={(run) => (
-                <div className="list-row compact-list-row" key={run.id}>
+            <ItemList<DirectorStatusResponse["recentActivity"][number]>
+              empty="No recent activity yet."
+              items={status?.recentActivity ?? []}
+              render={(activity) => (
+                <div className="list-row compact-list-row" key={activity.id}>
                   <div>
-                    <div className="list-title">{formatRunTitle(run)}</div>
+                    <div className="list-title">{activity.summary}</div>
                     <div className="list-meta">
-                      <span>{formatRunStatus(run.status)}</span>
-                      {run.issueNumber ? <span>Issue #{run.issueNumber}</span> : null}
-                      {run.prNumber ? <span>PR #{run.prNumber}</span> : null}
+                      {activity.laneName ? <span>{activity.laneName}</span> : null}
+                      {activity.issueNumber ? <span>Issue #{activity.issueNumber}</span> : null}
+                      {activity.pullRequestNumber ? <span>PR #{activity.pullRequestNumber}</span> : null}
+                      <span>{formatTimestamp(activity.createdAt)}</span>
                     </div>
                   </div>
-                  <div className="list-note">{run.summary}</div>
-                  <RunOutputDetails run={run} summaryLabel="Run output" />
                 </div>
               )}
             />

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -2109,15 +2109,6 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
       .filter((pullRequest) => pullRequest.state.toLowerCase() === "open")
       .sort((left, right) => left.number - right.number);
 
-    const workItems = issues
-      .filter((issue) => issue.state.toLowerCase() === "open")
-      .map((issue) => {
-        const linkedPullRequest =
-          pullRequests.find((pullRequest) => pullRequest.linkedIssueNumbers.includes(issue.number)) ??
-          null;
-        return synthesizeWorkItem(session.project, issue, linkedPullRequest, router);
-      });
-
     return {
       project: session.project,
       orchestrator: synthesizeOrchestratorStatus(session.project, router, owner),
@@ -2126,20 +2117,7 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
       issues: issues.map((issue) => synthesizeIssueOwnership(issue, router, pullRequests)),
       openQuestion: router.openQuestion ? toHumanQuestionRecord(router.openQuestion) : null,
       recentActivity: synthesizeActivity(router),
-      openPullRequests,
-      queue: workItems
-        .filter((workItem) => ["queued", "ready", "planning"].includes(workItem.status))
-        .sort((left, right) => left.priorityBucket - right.priorityBucket || left.issueNumber - right.issueNumber),
-      activeWork: workItems
-        .filter((workItem) => ["running", "waiting_review", "waiting_decision"].includes(workItem.status))
-        .sort((left, right) => left.issueNumber - right.issueNumber),
-      decisions: router.openQuestion ? [toHumanQuestionRecord(router.openQuestion)] : [],
-      prCycles: openPullRequests.map((pullRequest) => synthesizePrCycle(session.project, pullRequest)),
-      recentRuns: router.recentRuns.slice(-12),
-      notes: router.notes
-        .slice()
-        .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-        .slice(0, 10)
+      openPullRequests
     };
   });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -382,12 +382,6 @@ export interface DirectorStatusResponse {
   openQuestion: HumanQuestionRecord | null;
   recentActivity: ActivityRecord[];
   openPullRequests: GitHubPullRequestRecord[];
-  queue?: WorkItemRecord[];
-  activeWork?: WorkItemRecord[];
-  decisions?: HumanQuestionRecord[];
-  prCycles?: PrCycleRecord[];
-  recentRuns?: RunRecord[];
-  notes?: DirectorNoteRecord[];
 }
 
 export interface ConversationResponse {


### PR DESCRIPTION
## Summary
- remove the legacy queue/work-item compatibility fields from the main status contract
- pivot the web sidebar to lanes, lane-owned issues, current blocker state, recent activity, and linked PR visibility
- simplify the CLI around CoS chat plus lane visibility while demoting the old decision commands to explicit debug paths

## Issues
Refs #53
Refs #56
Part of #50
Stacks on #58

## Testing
- npm run typecheck
- npm run build
