### PR TITLE
Fix masked lane agent failures and worktree routing

### DIFF
--- a/packages/core/src/agents.test.ts
+++ b/packages/core/src/agents.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { codexOutputSchema } from "./agents.js";
+
+describe("codexOutputSchema", () => {
+  it("requires every top-level property that it declares", () => {
+    expect([...codexOutputSchema.required].sort()).toEqual(
+      Object.keys(codexOutputSchema.properties).sort()
+    );
+  });
+
+  it("uses a strict nested data schema that satisfies Codex structured output requirements", () => {
+    const dataSchema = (
+      codexOutputSchema.properties as {
+        data: {
+          additionalProperties: boolean;
+          properties: Record<string, unknown>;
+          required: string[];
+        };
+      }
+    ).data;
+
+    expect(dataSchema.additionalProperties).toBe(false);
+    expect([...dataSchema.required].sort()).toEqual(
+      Object.keys(dataSchema.properties).sort()
+    );
+  });
+});

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -57,6 +57,27 @@ const issueTaskSchema = {
 const structuredDataSchema = {
   type: "object",
   additionalProperties: false,
+  required: [
+    "outcome",
+    "owner_type",
+    "lane_id",
+    "lane_name",
+    "guidance",
+    "transcript_reply",
+    "why_it_matters",
+    "question",
+    "recommendation",
+    "selected_issue_number",
+    "execution_intent",
+    "rationale",
+    "new_issues",
+    "child_tasks",
+    "decision",
+    "feedback",
+    "kind",
+    "reply",
+    "command_error"
+  ],
   properties: {
     outcome: { type: ["string", "null"] },
     owner_type: { type: ["string", "null"] },
@@ -86,7 +107,7 @@ const structuredDataSchema = {
   }
 } as const;
 
-const outputSchema = {
+export const codexOutputSchema = {
   type: "object",
   additionalProperties: false,
   required: [
@@ -94,7 +115,8 @@ const outputSchema = {
     "summary",
     "recommended_next_action",
     "artifact_refs",
-    "blocking_questions"
+    "blocking_questions",
+    "data"
   ],
   properties: {
     status: {
@@ -422,7 +444,7 @@ export async function runCodexSessionAgent(
   const schemaPath = path.join(runtimePaths.tmpDir, `${stem}.schema.json`);
   const outputPath = path.join(runtimePaths.tmpDir, `${stem}.output.json`);
 
-  await fs.writeFile(schemaPath, `${JSON.stringify(outputSchema, null, 2)}\n`, "utf8");
+  await fs.writeFile(schemaPath, `${JSON.stringify(codexOutputSchema, null, 2)}\n`, "utf8");
 
   const args = [
     "exec",
@@ -476,14 +498,15 @@ export async function runCodexSessionAgent(
     return {
       sessionId,
       result:
-        fallback ??
         {
           status: "failed",
           summary: `Codex agent failed for ${input.role}: ${detail || String(error)}`,
-          recommended_next_action: "Review the prompt, model, or workspace permissions and retry.",
+          recommended_next_action:
+            fallback?.recommended_next_action ??
+            "Review the prompt, model, or workspace permissions and retry.",
           artifact_refs: [],
           blocking_questions: [],
-          data: detail ? { command_error: detail } : {},
+          data: detail ? { ...(fallback?.data ?? {}), command_error: detail } : fallback?.data ?? {},
           raw_model_output: rawModelOutput
         }
     };

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -1603,6 +1603,7 @@ function applyLaneTurn(
       raw_model_output?: string | null;
     };
     issueNumber: number;
+    worktreePath?: string | null;
   }
 ): RouterState {
   lane.sessionId = input.sessionId ?? lane.sessionId;
@@ -1625,7 +1626,7 @@ function applyLaneTurn(
     blockingQuestions: input.result.blocking_questions,
     outputJson: input.result.data ?? null,
     rawModelOutput: input.result.raw_model_output ?? null,
-    worktreePath: null
+    worktreePath: input.worktreePath ?? null
   });
 }
 
@@ -2701,10 +2702,9 @@ async function dispatchPendingHandoff(session: ProjectSession): Promise<boolean>
   const turn = await runCodexSessionAgent(
     {
       role: "lane_owner",
-      cwd: session.project.repoPath,
+      cwd: ensuredWorktree.worktreePath,
       model: session.project.model,
       allowWrite: true,
-      addDirs: [session.project.worktreeRoot],
       prompt: buildLaneImplementationPrompt(session, lane, issue, handoff),
       sessionId: lane.sessionId
     },
@@ -2724,7 +2724,8 @@ async function dispatchPendingHandoff(session: ProjectSession): Promise<boolean>
     sessionId: turn.sessionId,
     phase: handoff.kind,
     result: turn.result,
-    issueNumber: issue.number
+    issueNumber: issue.number,
+    worktreePath: ensuredWorktree.worktreePath
   });
   const relay = parseDataString(turn.result.data?.transcript_reply) ?? turn.result.summary;
 


### PR DESCRIPTION
## Summary
- fix the Codex structured output schema so agent runs stop failing before work begins
- stop treating command failures as successful fallback lane runs
- run lane implementation turns from the assigned issue worktree and store that path in run records

## Verification
- npm run typecheck
- npm test
- npm run build
- minimal `runCodexSessionAgent(...)` repro now returns a real structured response instead of falling back

## Links
Fixes #80
