### PR TITLE
Show last successful GitHub sync time in the control room

### DIFF
--- a/packages/core/src/services.test.ts
+++ b/packages/core/src/services.test.ts
@@ -10,7 +10,8 @@ import type { ProjectRecord } from "@director-os/shared";
 import type { StoredProjectConfig } from "./config.js";
 import {
   ensureIssueWorktree,
-  reconcileProjectConfigWithRepository
+  reconcileProjectConfigWithRepository,
+  resolveLastSuccessfulSyncAt
 } from "./services.js";
 
 const execFileAsync = promisify(execFile);
@@ -185,5 +186,29 @@ describe("ensureIssueWorktree", () => {
     } finally {
       await cleanup();
     }
+  });
+});
+
+describe("resolveLastSuccessfulSyncAt", () => {
+  it("falls back to the GitHub cache timestamp when router state has not recorded one yet", () => {
+    expect(
+      resolveLastSuccessfulSyncAt(null, "2026-04-05T12:00:00.000Z")
+    ).toBe("2026-04-05T12:00:00.000Z");
+  });
+
+  it("prefers the freshest successful sync timestamp when router and cache values differ", () => {
+    expect(
+      resolveLastSuccessfulSyncAt(
+        "2026-04-05T11:45:00.000Z",
+        "2026-04-05T12:00:00.000Z"
+      )
+    ).toBe("2026-04-05T12:00:00.000Z");
+  });
+
+  it("ignores malformed timestamps instead of surfacing an invalid sync time", () => {
+    expect(
+      resolveLastSuccessfulSyncAt("not-a-timestamp", "2026-04-05T12:00:00.000Z")
+    ).toBe("2026-04-05T12:00:00.000Z");
+    expect(resolveLastSuccessfulSyncAt("not-a-timestamp", "also-bad")).toBeNull();
   });
 });

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -439,6 +439,35 @@ export function reconcileProjectConfigWithRepository(
   };
 }
 
+function normalizeSuccessfulSyncTimestamp(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed && Number.isFinite(Date.parse(trimmed)) ? trimmed : null;
+}
+
+export function resolveLastSuccessfulSyncAt(
+  routerLastSyncAt: string | null | undefined,
+  cacheSyncedAt: string | null | undefined
+): string | null {
+  const routerTimestamp = normalizeSuccessfulSyncTimestamp(routerLastSyncAt);
+  const cacheTimestamp = normalizeSuccessfulSyncTimestamp(cacheSyncedAt);
+
+  if (!routerTimestamp) {
+    return cacheTimestamp;
+  }
+
+  if (!cacheTimestamp) {
+    return routerTimestamp;
+  }
+
+  return Date.parse(routerTimestamp) >= Date.parse(cacheTimestamp)
+    ? routerTimestamp
+    : cacheTimestamp;
+}
+
 async function getCurrentGitBranch(repoPath: string): Promise<string | null> {
   try {
     const branch = await runCommandOrThrow("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
@@ -3226,7 +3255,7 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
     return {
       project: session.project,
       orchestrator: synthesizeOrchestratorStatus(session.project, router, owner),
-      lastSuccessfulSyncAt: router.lastSyncAt,
+      lastSuccessfulSyncAt: resolveLastSuccessfulSyncAt(router.lastSyncAt, cache.syncedAt),
       lanes: router.lanes.map((lane) => synthesizeLaneRecord(lane, openPullRequests)),
       issues: issues.map((issue) => synthesizeIssueOwnership(issue, router, pullRequests)),
       openQuestion: router.openQuestion ? toHumanQuestionRecord(router.openQuestion) : null,


### PR DESCRIPTION
Fixes #30

Patched Director OS status resolution so the control room always receives the freshest valid successful GitHub sync timestamp, including fallback to cached sync history, and added regression coverage. Branch is ready for commit.