### PR TITLE
Avoid stale issue worktree reuse on reruns

### DIFF
--- a/packages/core/src/git-worktrees.test.ts
+++ b/packages/core/src/git-worktrees.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   parseGitWorktreeList,
-  selectReusableGitWorktree
+  selectReusableGitWorktree,
+  shouldReuseCleanIssueWorktree
 } from "./git-worktrees.js";
 
 describe("parseGitWorktreeList", () => {
@@ -82,5 +83,37 @@ describe("selectReusableGitWorktree", () => {
       branchName: "codex/issue-30",
       isPrunable: false
     });
+  });
+});
+
+describe("shouldReuseCleanIssueWorktree", () => {
+  it("reuses a clean branch when it already matches the current default branch tip", () => {
+    expect(
+      shouldReuseCleanIssueWorktree({
+        branchHeadRevision: "abc123",
+        defaultBranchRevision: "abc123",
+        branchCommitsBehind: 0
+      })
+    ).toBe(true);
+  });
+
+  it("reuses a clean branch when it still contains the current default branch tip", () => {
+    expect(
+      shouldReuseCleanIssueWorktree({
+        branchHeadRevision: "def456",
+        defaultBranchRevision: "abc123",
+        branchCommitsBehind: 0
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a clean branch that has fallen behind the current default branch tip", () => {
+    expect(
+      shouldReuseCleanIssueWorktree({
+        branchHeadRevision: "def456",
+        defaultBranchRevision: "abc123",
+        branchCommitsBehind: 2
+      })
+    ).toBe(false);
   });
 });

--- a/packages/core/src/git-worktrees.ts
+++ b/packages/core/src/git-worktrees.ts
@@ -67,3 +67,11 @@ export function selectReusableGitWorktree(
     ) ?? null
   );
 }
+
+export function shouldReuseCleanIssueWorktree(input: {
+  branchHeadRevision: string;
+  defaultBranchRevision: string;
+  branchCommitsBehind: number;
+}): boolean {
+  return input.branchHeadRevision === input.defaultBranchRevision || input.branchCommitsBehind === 0;
+}

--- a/packages/core/src/services.test.ts
+++ b/packages/core/src/services.test.ts
@@ -1,7 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
 import { describe, expect, it } from "vitest";
 
+import type { ProjectRecord } from "@director-os/shared";
 import type { StoredProjectConfig } from "./config.js";
-import { reconcileProjectConfigWithRepository } from "./services.js";
+import {
+  ensureIssueWorktree,
+  reconcileProjectConfigWithRepository
+} from "./services.js";
+
+const execFileAsync = promisify(execFile);
 
 function makeProjectConfig(
   overrides: Partial<StoredProjectConfig> = {}
@@ -20,6 +32,48 @@ function makeProjectConfig(
     model: "gpt-5.4",
     updatedAt: "2026-04-05T00:00:00.000Z",
     ...overrides
+  };
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+async function createTempProjectRecord(): Promise<{
+  cleanup: () => Promise<void>;
+  project: ProjectRecord;
+}> {
+  const sandboxRoot = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "director-os-worktree-"))
+  );
+  const repoPath = path.join(sandboxRoot, "repo");
+  const worktreeRoot = path.join(sandboxRoot, "worktrees");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(worktreeRoot, { recursive: true });
+
+  await runGit(repoPath, ["init", "-b", "main"]);
+  await runGit(repoPath, ["config", "user.name", "Codex"]);
+  await runGit(repoPath, ["config", "user.email", "codex@example.com"]);
+  await fs.writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+  await runGit(repoPath, ["add", "README.md"]);
+  await runGit(repoPath, ["commit", "-m", "Initial commit"]);
+
+  return {
+    cleanup: () => fs.rm(sandboxRoot, { recursive: true, force: true }),
+    project: {
+      id: 1,
+      name: "Director OS",
+      slug: "director-os",
+      repoPath,
+      repoSlug: "njuneja27/director-os",
+      defaultBranch: "main",
+      worktreeRoot,
+      agentRunner: "codex",
+      model: "gpt-5.4",
+      createdAt: "2026-04-05T00:00:00.000Z",
+      updatedAt: "2026-04-05T00:00:00.000Z"
+    }
   };
 }
 
@@ -72,5 +126,64 @@ describe("reconcileProjectConfigWithRepository", () => {
     expect(reconciled.changes).toContain(
       "Updated repo slug from old/director-os to njuneja27/director-os."
     );
+  });
+});
+
+describe("ensureIssueWorktree", () => {
+  it("creates a fresh rerun worktree when a clean issue branch has diverged behind main", async () => {
+    const { cleanup, project } = await createTempProjectRecord();
+    const issueNumber = 55;
+    const branchName = "codex/issue-55-route-all-blocker-handling-through-t";
+    const worktreePath = path.join(project.worktreeRoot, `issue-${issueNumber}`);
+
+    try {
+      await ensureIssueWorktree(project, issueNumber, branchName, worktreePath);
+
+      await fs.writeFile(path.join(worktreePath, "issue.txt"), "issue work\n", "utf8");
+      await runGit(worktreePath, ["add", "issue.txt"]);
+      await runGit(worktreePath, ["commit", "-m", "Issue branch commit"]);
+
+      await fs.writeFile(path.join(project.repoPath, "main.txt"), "main update\n", "utf8");
+      await runGit(project.repoPath, ["add", "main.txt"]);
+      await runGit(project.repoPath, ["commit", "-m", "Main branch commit"]);
+
+      const refreshed = await ensureIssueWorktree(project, issueNumber, branchName, worktreePath);
+
+      expect(refreshed.branchName).toBe(`${branchName}-rerun-1`);
+      expect(refreshed.worktreePath).toBe(`${worktreePath}-rerun-1`);
+      expect(await runGit(refreshed.worktreePath, ["rev-parse", "HEAD"])).toBe(
+        await runGit(project.repoPath, ["rev-parse", "main"])
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves the existing branch when the issue already has an open PR branch to refine", async () => {
+    const { cleanup, project } = await createTempProjectRecord();
+    const issueNumber = 55;
+    const branchName = "codex/issue-55-route-all-blocker-handling-through-t";
+    const worktreePath = path.join(project.worktreeRoot, `issue-${issueNumber}`);
+
+    try {
+      await ensureIssueWorktree(project, issueNumber, branchName, worktreePath);
+
+      await fs.writeFile(path.join(worktreePath, "issue.txt"), "issue work\n", "utf8");
+      await runGit(worktreePath, ["add", "issue.txt"]);
+      await runGit(worktreePath, ["commit", "-m", "Issue branch commit"]);
+
+      await fs.writeFile(path.join(project.repoPath, "main.txt"), "main update\n", "utf8");
+      await runGit(project.repoPath, ["add", "main.txt"]);
+      await runGit(project.repoPath, ["commit", "-m", "Main branch commit"]);
+
+      const preserved = await ensureIssueWorktree(project, issueNumber, branchName, worktreePath, {
+        preserveExistingBranch: true
+      });
+
+      expect(preserved.branchName).toBe(branchName);
+      expect(preserved.worktreePath).toBe(worktreePath);
+    } finally {
+      await cleanup();
+    }
   });
 });

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -67,7 +67,11 @@ import {
   resolveRepoPath,
   viewPullRequest
 } from "./github.js";
-import { parseGitWorktreeList, selectReusableGitWorktree } from "./git-worktrees.js";
+import {
+  parseGitWorktreeList,
+  selectReusableGitWorktree,
+  shouldReuseCleanIssueWorktree
+} from "./git-worktrees.js";
 import {
   createDefaultConversationState,
   initializeProjectRuntime,
@@ -1108,6 +1112,58 @@ async function localBranchExists(repoPath: string, branchName: string): Promise<
   }
 }
 
+async function resolveGitRevision(repoPath: string, ref: string): Promise<string> {
+  const revision = await runCommandOrThrow("git", ["-C", repoPath, "rev-parse", ref], {
+    cwd: repoPath
+  });
+  return revision.trim();
+}
+
+async function resolveComparablePath(targetPath: string): Promise<string> {
+  try {
+    return await fs.realpath(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+async function countBranchCommitsBehind(
+  repoPath: string,
+  baseRef: string,
+  branchRef: string
+): Promise<number> {
+  const count = await runCommandOrThrow(
+    "git",
+    ["-C", repoPath, "rev-list", "--count", `${branchRef}..${baseRef}`],
+    { cwd: repoPath }
+  );
+  return Number.parseInt(count.trim(), 10) || 0;
+}
+
+async function canReuseCleanIssueWorktree(
+  project: ProjectRecord,
+  branchName: string,
+  options: {
+    preserveExistingBranch?: boolean;
+  } = {}
+): Promise<boolean> {
+  if (options.preserveExistingBranch) {
+    return true;
+  }
+
+  const [branchHeadRevision, defaultBranchRevision, branchCommitsBehind] = await Promise.all([
+    resolveGitRevision(project.repoPath, branchName),
+    resolveGitRevision(project.repoPath, project.defaultBranch),
+    countBranchCommitsBehind(project.repoPath, project.defaultBranch, branchName)
+  ]);
+
+  return shouldReuseCleanIssueWorktree({
+    branchHeadRevision,
+    defaultBranchRevision,
+    branchCommitsBehind
+  });
+}
+
 function suffixedWorktreeTarget(baseValue: string, attempt: number): string {
   return attempt === 0 ? baseValue : `${baseValue}-rerun-${attempt}`;
 }
@@ -1195,20 +1251,38 @@ async function resetWorktreeValidationState(worktreePath: string): Promise<void>
   );
 }
 
-async function ensureIssueWorktree(
+export async function ensureIssueWorktree(
   project: ProjectRecord,
   issueNumber: number,
   branchName: string,
-  worktreePath: string
+  worktreePath: string,
+  options: {
+    preserveExistingBranch?: boolean;
+  } = {}
 ): Promise<{ branchName: string; worktreePath: string }> {
   await fs.mkdir(project.worktreeRoot, { recursive: true });
   await pruneGitWorktrees(project.repoPath);
 
-  const entries = (await listGitWorktrees(project.repoPath)).filter(
-    (entry) =>
-      entry.path === worktreePath ||
-      entry.path.startsWith(`${project.worktreeRoot}${path.sep}`)
-  );
+  const [desiredComparablePath, worktreeRootComparablePath, rawEntries] = await Promise.all([
+    resolveComparablePath(worktreePath),
+    resolveComparablePath(project.worktreeRoot),
+    listGitWorktrees(project.repoPath)
+  ]);
+
+  const entries = (
+    await Promise.all(
+      rawEntries.map(async (entry) => ({
+        entry,
+        comparablePath: await resolveComparablePath(entry.path)
+      }))
+    )
+  )
+    .filter(
+      ({ comparablePath }) =>
+        comparablePath === desiredComparablePath ||
+        comparablePath.startsWith(`${worktreeRootComparablePath}${path.sep}`)
+    )
+    .map(({ entry }) => entry);
 
   const reusable = selectReusableGitWorktree(
     entries,
@@ -1219,7 +1293,8 @@ async function ensureIssueWorktree(
   if (
     reusable &&
     (await pathExists(reusable.path)) &&
-    !(await worktreeHasUncommittedChanges(reusable.path))
+    !(await worktreeHasUncommittedChanges(reusable.path)) &&
+    (await canReuseCleanIssueWorktree(project, reusable.branchName ?? branchName, options))
   ) {
     await ensureWorktreeNodeModules(project, reusable.path);
     return {
@@ -2693,7 +2768,10 @@ async function dispatchPendingHandoff(session: ProjectSession): Promise<boolean>
     session.project,
     issue.number,
     handoff.branchName ?? branchNameForIssue(issue),
-    handoff.worktreePath ?? path.join(session.project.worktreeRoot, `issue-${issue.number}`)
+    handoff.worktreePath ?? path.join(session.project.worktreeRoot, `issue-${issue.number}`),
+    {
+      preserveExistingBranch: handoff.prNumber != null
+    }
   );
   handoff.branchName = ensuredWorktree.branchName;
   handoff.worktreePath = ensuredWorktree.worktreePath;


### PR DESCRIPTION
Fixes #86

## Summary
- refuse to reuse clean issue worktrees that have fallen behind the current base branch
- preserve an existing issue branch when the lane is refining an already-open PR
- normalize worktree path comparisons so `/var` and `/private/var` aliases do not hide live worktrees on macOS
- add regression coverage for stale reruns and preserve-existing-branch behavior