### PR TITLE
Reduce source-checkout startup to one documented command with a first-run bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Director OS
 
+## Source Checkout Startup
+
+From the repository root, use one command to launch the desktop app from source:
+
+1. `npm start`
+
+What `npm start` does for you:
+
+- bootstraps workspace dependencies with `npm install` when the checkout is new or `package-lock.json` is newer than the installed dependency state
+- rebuilds the shared package, core package, web renderer, desktop shell, and CLI before launch
+- opens the Electron desktop app once the checkout is current
+
+First run:
+
+- run `npm start`
+- expect dependency installation plus a full rebuild before the desktop window opens
+
+Normal relaunch:
+
+- run `npm start`
+- dependency installation is skipped when the checkout is already bootstrapped, but build artifacts are still refreshed before launch so the app does not use stale `dist` output
+
 ## What We Want To Do
 
 Director OS is a local-first orchestration engine for running a software product with AI agents while the human stays at the level of direction, taste, and exception handling.
@@ -67,11 +89,10 @@ The primary desktop experience is:
 
 ## Dogfood Smoke Test
 
-When operating Director OS from this source checkout rather than an installed build, rebuild first so the local `dist` artifacts match the current source before using the CLI directly.
+After launching the desktop app from source, the CLI remains available for smoke tests and debugging.
 
-1. `npm run build`
-2. `node apps/cli/dist/index.js sync`
-3. `node apps/cli/dist/index.js status`
+1. `npm run director -- sync`
+2. `npm run director -- status`
 
 Expected result:
 
@@ -79,24 +100,15 @@ Expected result:
 - newly opened GitHub issues do appear in `status.queue`
 - the control-room queue only shows open, claimable work
 
-### Validated Local Smoke-Test Path
+### Advanced and Debug Paths
 
-When using the CLI directly, prefer the root `director` script so commands run against a fresh build instead of potentially stale compiled artifacts.
+The lower-level entrypoints are still available when you need them, but they are no longer the default source-checkout instructions.
 
-Examples:
-
-- `npm run director -- status`
-- `npm run director -- sync`
-- `npm run director -- conversation`
-- `npm run director -- message "Focus on setup reliability before UI polish."`
-- `npm run director -- start`
-- `npm run director -- pause --reason "manual stop"`
-
-For desktop dogfooding, prefer:
-
-- `npm run desktop:start`
-
-This path rebuilds the desktop shell, renderer, core package, and CLI before launch.
+- `npm run desktop:start` is the legacy alias for `npm start`
+- `npm run desktop:build` refreshes the desktop app artifacts without launching Electron
+- `npm run director -- <command>` runs CLI commands against a fresh build
+- `npm run desktop:dev` starts the live-reload desktop development loop
+- `npm --prefix apps/desktop run start` launches Electron directly against whatever artifacts are already built
 
 ## Scope
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "packages/core"
   ],
   "scripts": {
+    "start": "node ./scripts/start-desktop.mjs",
     "build": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/web run build && npm --prefix apps/desktop run build && npm --prefix apps/cli run build",
     "director": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/cli run build && node apps/cli/dist/index.js",
     "desktop:build": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/web run build && npm --prefix apps/desktop run build && npm --prefix apps/cli run build",
-    "desktop:start": "npm run desktop:build && npm --prefix apps/desktop run start",
+    "desktop:start": "node ./scripts/start-desktop.mjs",
     "desktop:dev": "npm --prefix apps/cli run build && concurrently -k -n renderer,desktop-ts,electron -c auto \"npm --prefix apps/web run dev -- --host 127.0.0.1\" \"npm --prefix apps/desktop run build:watch\" \"wait-on tcp:4310 file:apps/desktop/dist/main.js && VITE_DEV_SERVER_URL=http://127.0.0.1:4310 npm --prefix apps/desktop run dev\"",
     "typecheck": "npm --prefix packages/shared run build && npm --prefix packages/core run build && npm --prefix apps/web run typecheck && npm --prefix apps/desktop run typecheck && npm --prefix apps/cli run typecheck",
     "dev": "npm --prefix apps/web run dev",

--- a/scripts/start-desktop.mjs
+++ b/scripts/start-desktop.mjs
@@ -1,0 +1,92 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const nodeModulesPath = path.join(rootDir, "node_modules");
+const packageLockPath = path.join(rootDir, "package-lock.json");
+const installedLockPath = path.join(nodeModulesPath, ".package-lock.json");
+const electronPackagePath = path.join(nodeModulesPath, "electron");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+const rawArgs = process.argv.slice(2);
+const bootstrapOnly = rawArgs.includes("--bootstrap-only");
+const launchArgs = rawArgs.filter((arg) => arg !== "--bootstrap-only");
+
+function logStep(message) {
+  console.log(`[director-os] ${message}`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === "number" && result.status !== 0) {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    logStep(`Command terminated by signal ${result.signal}.`);
+    process.exit(1);
+  }
+}
+
+function needsDependencyBootstrap() {
+  if (!existsSync(nodeModulesPath)) {
+    return true;
+  }
+
+  if (!existsSync(electronPackagePath)) {
+    return true;
+  }
+
+  try {
+    if (lstatSync(nodeModulesPath).isSymbolicLink()) {
+      return false;
+    }
+  } catch {
+    return true;
+  }
+
+  if (!existsSync(packageLockPath) || !existsSync(installedLockPath)) {
+    return true;
+  }
+
+  try {
+    return statSync(installedLockPath).mtimeMs < statSync(packageLockPath).mtimeMs;
+  } catch {
+    return true;
+  }
+}
+
+if (needsDependencyBootstrap()) {
+  logStep("First run or dependency refresh detected. Running npm install.");
+  run(npmCommand, ["install"]);
+} else {
+  logStep("Workspace dependencies are already bootstrapped.");
+}
+
+logStep("Refreshing desktop build artifacts.");
+run(npmCommand, ["run", "desktop:build"]);
+
+if (bootstrapOnly) {
+  logStep("Bootstrap-only run complete. Skipping desktop launch.");
+  process.exit(0);
+}
+
+logStep("Launching the desktop app.");
+const desktopStartArgs = ["--prefix", "apps/desktop", "run", "start"];
+
+if (launchArgs.length > 0) {
+  desktopStartArgs.push("--", ...launchArgs);
+}
+
+run(npmCommand, desktopStartArgs);


### PR DESCRIPTION
Fixes #78

Implemented issue #78 in the assigned worktree: added a single root `npm start` desktop launcher with first-run dependency bootstrap, rewired the legacy desktop start alias to the same path, updated the README so source-checkout startup has one dominant command with clear first-run vs relaunch guidance, and staged the changes after verification.