### PR TITLE
Move macOS runtime state into Application Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ For desktop dogfooding, prefer:
 
 This path rebuilds the desktop shell, renderer, core package, and CLI before launch.
 
+### Runtime Storage On macOS
+
+New macOS installs store Director OS runtime state under `~/Library/Application Support/Director OS`.
+
+- app-managed config, runtime state, logs, and default worktrees live under Application Support
+- temporary Codex scratch data lives under `~/Library/Caches/Director OS/tmp`
+- existing dogfood installs that already use `~/.director-os` continue to work through a compatibility path instead of being auto-migrated
+
 ## Scope
 
 ### MVP

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -630,7 +630,8 @@ function SetupWorkspace(props: {
           <h1 className="hero-title">Bring Director OS online on this computer.</h1>
           <p className="hero-copy">
             Director OS stays local. It checks the repository, GitHub CLI, Codex CLI, and a safe
-            workspace test before the control room appears.
+            workspace test before the control room appears. On macOS, new installs live in
+            Application Support and use Library/Caches for temporary files.
           </p>
           <div className="step-stack">
             <SetupStepCard index={1} title="Landing" body="Start the setup conversation." active={props.setupStep === "landing"} />

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import type { AgentResultEnvelope } from "@director-os/shared";
 
-import { ensureRuntimeDirectories, resolveRuntimePaths, slugify } from "./config.js";
+import { ensureRuntimeDirectories, slugify } from "./config.js";
 import {
   commandErrorText,
   isMissingBinaryError,
@@ -231,7 +231,7 @@ export async function probeCodexCli(
   model = "gpt-5.4-mini",
   runner: CommandRunner = runCommandCapture
 ): Promise<CodexProbeResult> {
-  const runtimePaths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const runtimePaths = await ensureRuntimeDirectories();
   const stem = `codex-probe-${Date.now()}`;
   const schemaPath = path.join(runtimePaths.tmpDir, `${stem}.schema.json`);
   const outputPath = path.join(runtimePaths.tmpDir, `${stem}.output.json`);
@@ -315,7 +315,7 @@ export async function probeCodexCli(
 export async function runCodexSessionTurn(
   input: RunAgentOptions
 ): Promise<CodexSessionTurnResult> {
-  const runtimePaths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const runtimePaths = await ensureRuntimeDirectories();
   const stem = `${slugify(input.role)}-${Date.now()}`;
   const outputPath = path.join(runtimePaths.tmpDir, `${stem}.message.txt`);
 
@@ -434,7 +434,7 @@ export async function runCodexSessionAgent(
     };
   }
 
-  const runtimePaths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const runtimePaths = await ensureRuntimeDirectories();
   const stem = `${slugify(input.role)}-${Date.now()}`;
   const schemaPath = path.join(runtimePaths.tmpDir, `${stem}.schema.json`);
   const outputPath = path.join(runtimePaths.tmpDir, `${stem}.output.json`);

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ensureRuntimeDirectories,
+  resolveActiveRuntimePaths,
+  resolveDefaultRuntimeHomeDir,
+  resolveLegacyRuntimeHomeDir
+} from "./config.js";
+
+const cleanupTargets = new Set<string>();
+
+async function createSandboxHome(): Promise<string> {
+  const sandboxHome = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "director-os-runtime-home-"))
+  );
+  cleanupTargets.add(sandboxHome);
+  return sandboxHome;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    [...cleanupTargets].map((target) => fs.rm(target, { recursive: true, force: true }))
+  );
+  cleanupTargets.clear();
+});
+
+describe("resolveActiveRuntimePaths", () => {
+  it("uses Application Support and Library/Caches for fresh macOS installs", async () => {
+    const homedir = await createSandboxHome();
+
+    const paths = await resolveActiveRuntimePaths({
+      homedir,
+      platform: "darwin"
+    });
+
+    expect(paths.homeDir).toBe(
+      path.join(homedir, "Library", "Application Support", "Director OS")
+    );
+    expect(paths.tmpDir).toBe(path.join(homedir, "Library", "Caches", "Director OS", "tmp"));
+
+    await ensureRuntimeDirectories(paths);
+
+    await expect(fs.stat(paths.homeDir)).resolves.toBeTruthy();
+    await expect(fs.stat(paths.tmpDir)).resolves.toBeTruthy();
+  });
+
+  it("keeps using the legacy dotfolder when an older macOS install already exists", async () => {
+    const homedir = await createSandboxHome();
+    const legacyHomeDir = resolveLegacyRuntimeHomeDir({ homedir, platform: "darwin" });
+    await fs.mkdir(legacyHomeDir, { recursive: true });
+
+    const paths = await resolveActiveRuntimePaths({
+      homedir,
+      platform: "darwin"
+    });
+
+    expect(paths.homeDir).toBe(legacyHomeDir);
+    expect(paths.tmpDir).toBe(path.join(legacyHomeDir, "tmp"));
+  });
+
+  it("prefers the native macOS location once Application Support already exists", async () => {
+    const homedir = await createSandboxHome();
+    const preferredHomeDir = resolveDefaultRuntimeHomeDir({
+      homedir,
+      platform: "darwin"
+    });
+    const legacyHomeDir = resolveLegacyRuntimeHomeDir({ homedir, platform: "darwin" });
+
+    await fs.mkdir(preferredHomeDir, { recursive: true });
+    await fs.mkdir(legacyHomeDir, { recursive: true });
+
+    const paths = await resolveActiveRuntimePaths({
+      homedir,
+      platform: "darwin"
+    });
+
+    expect(paths.homeDir).toBe(preferredHomeDir);
+    expect(paths.tmpDir).toBe(path.join(homedir, "Library", "Caches", "Director OS", "tmp"));
+  });
+
+  it("leaves non-macOS defaults unchanged", async () => {
+    const homedir = await createSandboxHome();
+
+    const paths = await resolveActiveRuntimePaths({
+      homedir,
+      platform: "linux"
+    });
+
+    expect(paths.homeDir).toBe(path.join(homedir, ".director-os"));
+    expect(paths.tmpDir).toBe(path.join(homedir, ".director-os", "tmp"));
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -34,6 +34,11 @@ export interface RuntimePaths {
   orchestratorLockPath: string;
 }
 
+interface RuntimePathOptions {
+  homedir?: string;
+  platform?: NodeJS.Platform;
+}
+
 export function nowIso(): string {
   return new Date().toISOString();
 }
@@ -49,27 +54,89 @@ export function slugify(value: string): string {
   );
 }
 
-export function resolveRuntimePaths(homeDir = path.join(os.homedir(), ".director-os")): RuntimePaths {
+export function resolveLegacyRuntimeHomeDir(options: RuntimePathOptions = {}): string {
+  const homedir = options.homedir ?? os.homedir();
+  return path.join(homedir, ".director-os");
+}
+
+export function resolveDefaultRuntimeHomeDir(options: RuntimePathOptions = {}): string {
+  const homedir = options.homedir ?? os.homedir();
+  const platform = options.platform ?? process.platform;
+
+  return platform === "darwin"
+    ? path.join(homedir, "Library", "Application Support", "Director OS")
+    : resolveLegacyRuntimeHomeDir({ homedir, platform });
+}
+
+function resolveDefaultTmpDir(homeDir: string, options: RuntimePathOptions = {}): string {
+  const homedir = options.homedir ?? os.homedir();
+  const platform = options.platform ?? process.platform;
+  const preferredHomeDir = resolveDefaultRuntimeHomeDir({ homedir, platform });
+
+  return platform === "darwin" && path.normalize(homeDir) === path.normalize(preferredHomeDir)
+    ? path.join(homedir, "Library", "Caches", "Director OS", "tmp")
+    : path.join(homeDir, "tmp");
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveRuntimePaths(
+  homeDir = resolveDefaultRuntimeHomeDir(),
+  options: RuntimePathOptions = {}
+): RuntimePaths {
   return {
     homeDir,
     configPath: path.join(homeDir, "config.json"),
     runtimeDir: path.join(homeDir, "runtime"),
     logsDir: path.join(homeDir, "logs"),
     worktreesDir: path.join(homeDir, "worktrees"),
-    tmpDir: path.join(homeDir, "tmp"),
+    tmpDir: resolveDefaultTmpDir(homeDir, options),
     orchestratorLockPath: path.join(homeDir, "orchestrator.lock.json")
   };
 }
 
-export async function ensureRuntimeDirectories(paths = resolveRuntimePaths()): Promise<RuntimePaths> {
-  await fs.mkdir(paths.homeDir, { recursive: true });
+export async function resolveActiveRuntimePaths(
+  options: RuntimePathOptions = {}
+): Promise<RuntimePaths> {
+  const platform = options.platform ?? process.platform;
+  const preferredPaths = resolveRuntimePaths(resolveDefaultRuntimeHomeDir(options), options);
+
+  if (platform !== "darwin") {
+    return preferredPaths;
+  }
+
+  if (await pathExists(preferredPaths.homeDir)) {
+    return preferredPaths;
+  }
+
+  const legacyHomeDir = resolveLegacyRuntimeHomeDir(options);
+  if (path.normalize(legacyHomeDir) === path.normalize(preferredPaths.homeDir)) {
+    return preferredPaths;
+  }
+
+  return (await pathExists(legacyHomeDir))
+    ? resolveRuntimePaths(legacyHomeDir, options)
+    : preferredPaths;
+}
+
+export async function ensureRuntimeDirectories(paths?: RuntimePaths): Promise<RuntimePaths> {
+  const resolvedPaths = paths ?? (await resolveActiveRuntimePaths());
+
+  await fs.mkdir(resolvedPaths.homeDir, { recursive: true });
   await Promise.all([
-    fs.mkdir(paths.runtimeDir, { recursive: true }),
-    fs.mkdir(paths.logsDir, { recursive: true }),
-    fs.mkdir(paths.worktreesDir, { recursive: true }),
-    fs.mkdir(paths.tmpDir, { recursive: true })
+    fs.mkdir(resolvedPaths.runtimeDir, { recursive: true }),
+    fs.mkdir(resolvedPaths.logsDir, { recursive: true }),
+    fs.mkdir(resolvedPaths.worktreesDir, { recursive: true }),
+    fs.mkdir(resolvedPaths.tmpDir, { recursive: true })
   ]);
-  return paths;
+  return resolvedPaths;
 }
 
 function defaultConfig(): DirectorConfigFile {
@@ -110,11 +177,11 @@ function normalizeStoredProject(
   };
 }
 
-export async function loadConfig(paths = resolveRuntimePaths()): Promise<DirectorConfigFile> {
-  await ensureRuntimeDirectories(paths);
+export async function loadConfig(paths?: RuntimePaths): Promise<DirectorConfigFile> {
+  const resolvedPaths = await ensureRuntimeDirectories(paths);
 
   try {
-    const raw = await fs.readFile(paths.configPath, "utf8");
+    const raw = await fs.readFile(resolvedPaths.configPath, "utf8");
     const parsed = JSON.parse(raw) as Partial<DirectorConfigFile>;
 
     return {
@@ -122,7 +189,7 @@ export async function loadConfig(paths = resolveRuntimePaths()): Promise<Directo
       activeProjectSlug: parsed.activeProjectSlug ?? null,
       projects: Array.isArray(parsed.projects)
         ? parsed.projects.map((project, index) =>
-            normalizeStoredProject(project as Partial<StoredProjectConfig>, index, paths)
+            normalizeStoredProject(project as Partial<StoredProjectConfig>, index, resolvedPaths)
           )
         : [],
       updatedAt: parsed.updatedAt ?? nowIso()
@@ -130,7 +197,7 @@ export async function loadConfig(paths = resolveRuntimePaths()): Promise<Directo
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       const initial = defaultConfig();
-      await saveConfig(initial, paths);
+      await saveConfig(initial, resolvedPaths);
       return initial;
     }
 
@@ -138,14 +205,16 @@ export async function loadConfig(paths = resolveRuntimePaths()): Promise<Directo
   }
 }
 
-export async function saveConfig(config: DirectorConfigFile, paths = resolveRuntimePaths()): Promise<void> {
-  await ensureRuntimeDirectories(paths);
+export async function saveConfig(config: DirectorConfigFile, paths?: RuntimePaths): Promise<void> {
+  const resolvedPaths = await ensureRuntimeDirectories(paths);
   const nextConfig: DirectorConfigFile = {
     ...config,
-    projects: config.projects.map((project, index) => normalizeStoredProject(project, index, paths)),
+    projects: config.projects.map((project, index) =>
+      normalizeStoredProject(project, index, resolvedPaths)
+    ),
     updatedAt: nowIso()
   };
-  await fs.writeFile(paths.configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
+  await fs.writeFile(resolvedPaths.configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 }
 
 export function upsertProjectConfig(

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -43,7 +43,6 @@ import {
   getProjectConfig,
   loadConfig,
   nowIso,
-  resolveRuntimePaths,
   saveConfig,
   slugify,
   type DirectorConfigFile,
@@ -541,7 +540,7 @@ async function refreshProjectMetadata(session: ProjectSession): Promise<string[]
 async function withRuntime<TValue>(
   callback: (session: RuntimeSession) => Promise<TValue>
 ): Promise<TValue> {
-  const paths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const paths = await ensureRuntimeDirectories();
   const config = await loadConfig(paths);
   return callback({
     paths,
@@ -3580,7 +3579,7 @@ export async function completeSetup(
 }
 
 export async function initDirector(options: InitCommandOptions = {}) {
-  const paths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const paths = await ensureRuntimeDirectories();
   const repoPath = resolveRepoPath(options.repoPath ?? process.cwd());
 
   if (options.noProjectRegistration) {
@@ -3796,7 +3795,7 @@ export async function sendConversationMessage(content: string): Promise<Conversa
 }
 
 export async function startOrchestrator(): Promise<DirectorOperationResponse> {
-  const paths = await ensureRuntimeDirectories(resolveRuntimePaths());
+  const paths = await ensureRuntimeDirectories();
   const ownership = await acquireOrchestratorLock(paths);
 
   if (ownership === "busy") {
@@ -3852,6 +3851,6 @@ export async function pauseOrchestrator(reason?: string): Promise<DirectorOperat
     clearTimeout(orchestratorTimer);
     orchestratorTimer = null;
   }
-  await releaseOrchestratorLock(await ensureRuntimeDirectories(resolveRuntimePaths()));
+  await releaseOrchestratorLock(await ensureRuntimeDirectories());
   return response;
 }


### PR DESCRIPTION
Fixes #35

Implemented the bounded macOS runtime-path change for issue #35. Director OS now prefers `~/Library/Application Support/Director OS` on macOS, uses `~/Library/Caches/Director OS/tmp` for temporary scratch data, keeps existing `~/.director-os` installs on a safe compatibility path when the legacy directory already exists, and includes focused tests plus docs/setup messaging updates.