### PR TITLE
Add Chief of Staff PR sweep mode

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -20,7 +20,9 @@ async function printLaneVisibility(): Promise<void> {
   console.log(JSON.stringify({
     orchestrator: status.orchestrator,
     lastSuccessfulSyncAt: status.lastSuccessfulSyncAt,
+    prSweep: status.prSweep,
     openQuestion: status.openQuestion,
+    recentActivity: status.recentActivity,
     lanes: status.lanes,
     issues: status.issues,
     openPullRequests: status.openPullRequests

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -478,6 +478,20 @@ export function App() {
                     : "No successful sync yet"}
                 </span>
               </div>
+              <div className="meta-pair">
+                <span className="meta-pair-label">PR sweep</span>
+                <span className="meta-pair-value">
+                  {status?.prSweep
+                    ? status.prSweep.status === "running"
+                      ? "Running"
+                      : status.prSweep.pausedIssueWork
+                        ? "Pausing issue work"
+                        : status.prSweep.nextRunAt
+                          ? `Scheduled for ${formatTimestamp(status.prSweep.nextRunAt)}`
+                          : "Unscheduled"
+                    : "Unavailable"}
+                </span>
+              </div>
             </div>
             <div className="list-note">
               The Chief of Staff loop stays local and routes work through persistent lane sessions.
@@ -526,6 +540,73 @@ export function App() {
                   : "Reset local router runtime"}
               </button>
             </div>
+          </section>
+
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">PR sweep</div>
+                <div className="section-meta">The Chief of Staff periodically pauses normal issue routing to clear the open PR queue, then resumes backlog work.</div>
+              </div>
+            </div>
+            <ItemList<NonNullable<DirectorStatusResponse["prSweep"]>>
+              empty="PR sweep state is not available yet."
+              items={status?.prSweep ? [status.prSweep] : []}
+              render={(prSweep) => (
+                <div className="compact-card">
+                  <div className="compact-card-head">
+                    <div className="list-title">
+                      {prSweep.status === "running"
+                        ? "Sweep in progress"
+                        : prSweep.nextRunAt
+                          ? `Next sweep ${formatTimestamp(prSweep.nextRunAt)}`
+                          : "Sweep not scheduled"}
+                    </div>
+                    <span className="check-pill check-pill-needs-action">
+                      {prSweep.pausedIssueWork ? "Issue work paused" : prSweep.status}
+                    </span>
+                  </div>
+                  <div className="compact-card-meta">
+                    {prSweep.currentPullRequestNumber ? <span>Reviewing PR #{prSweep.currentPullRequestNumber}</span> : null}
+                    {prSweep.pendingPullRequestNumbers.length > 0 ? (
+                      <span>{prSweep.pendingPullRequestNumbers.length} PRs remaining</span>
+                    ) : null}
+                    {prSweep.waitingOnIssueNumber ? <span>Waiting on issue #{prSweep.waitingOnIssueNumber}</span> : null}
+                    {prSweep.completedAt ? <span>Last completed {formatTimestamp(prSweep.completedAt)}</span> : null}
+                  </div>
+                  <div className="list-note">
+                    {prSweep.lastSummary ?? "Chief of Staff will schedule the next PR sweep when the router is ready."}
+                  </div>
+                </div>
+              )}
+            />
+          </section>
+
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Recent activity</div>
+                <div className="section-meta">A compact timeline of recent CoS, lane, and PR sweep automation events.</div>
+              </div>
+            </div>
+            <ItemList<DirectorStatusResponse["recentActivity"][number]>
+              empty="No recent automation activity yet."
+              items={status?.recentActivity ?? []}
+              render={(activity) => (
+                <div className="list-row compact-list-row" key={activity.id}>
+                  <div>
+                    <div className="list-title">{activity.summary}</div>
+                    <div className="list-meta">
+                      <span>{activity.kind.replaceAll("_", " ")}</span>
+                      {activity.laneName ? <span>{activity.laneName}</span> : null}
+                      {activity.issueNumber ? <span>Issue #{activity.issueNumber}</span> : null}
+                      {activity.pullRequestNumber ? <span>PR #{activity.pullRequestNumber}</span> : null}
+                    </div>
+                  </div>
+                  <div className="list-note">{formatTimestamp(activity.createdAt)}</div>
+                </div>
+              )}
+            />
           </section>
 
           <section className="panel sidebar-card">
@@ -612,6 +693,7 @@ export function App() {
                     <div className="list-title">PR #{pullRequest.number} {pullRequest.title}</div>
                     <div className="list-meta">
                       <span>{pullRequest.reviewDecision ?? (pullRequest.isDraft ? "Draft" : "Open")}</span>
+                      {pullRequest.checksBucket ? <span>{pullRequest.checksBucket.replaceAll("_", " ")}</span> : null}
                       {pullRequest.linkedIssueNumbers[0] ? <span>Issue #{pullRequest.linkedIssueNumbers[0]}</span> : null}
                     </div>
                   </div>

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -73,6 +73,7 @@ const structuredDataSchema = {
     "new_issues",
     "decision",
     "feedback",
+    "pr_sweep_interval_hours",
     "kind",
     "reply",
     "command_error"
@@ -96,6 +97,7 @@ const structuredDataSchema = {
     },
     decision: { type: ["string", "null"] },
     feedback: { type: ["string", "null"] },
+    pr_sweep_interval_hours: { type: ["number", "null"] },
     kind: { type: ["string", "null"] },
     reply: { type: ["string", "null"] },
     command_error: { type: ["string", "null"] }

--- a/packages/core/src/cos.ts
+++ b/packages/core/src/cos.ts
@@ -33,10 +33,20 @@ export const COS_TASK_APPENDICES = {
     "If you choose `ask_human`, return `data.question`, `data.why_it_matters`, and `data.recommendation`.",
     "Keep Director OS thin: return a concise summary, not a custom plan object."
   ].join("\n"),
+  planPrSweep: [
+    "Task: choose when the next automated PR sweep should run.",
+    "Return `data.pr_sweep_interval_hours` as a number between 0 and 24.",
+    "Use `0` only when the next sweep should run immediately.",
+    "Bias toward short intervals when open PRs or recent PR blockers exist, and longer intervals when the queue is quiet.",
+    "Use `data.transcript_reply` for the short operational summary."
+  ].join("\n"),
   reviewPr: [
     "Task: review a real pull request and decide whether it is merge-ready.",
-    "Return `data.decision` as `merge`, `changes`, or `escalate`.",
+    "Return `data.decision` as `merge`, `changes`, `close`, `blocker_issue`, or `escalate`.",
     "If you choose `changes`, return concise `data.feedback` the implementer can act on.",
+    "If you choose `close`, use `data.feedback` as the closure rationale the Chief of Staff should post.",
+    "If you choose `blocker_issue`, return one GitHub-ready issue in `data.new_issues[0]` and use `data.feedback` as the PR update comment.",
+    "Only choose `escalate` for a true product or taste judgment the human must make.",
     "If you choose `escalate`, return `data.question`, `data.why_it_matters`, and `data.recommendation`."
   ].join("\n"),
   replyInChat: [

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -578,6 +578,27 @@ export async function mergePullRequest(repoPath: string, prNumber: number): Prom
   ], { cwd: repoPath });
 }
 
+export async function closePullRequest(
+  repoPath: string,
+  prNumber: number,
+  options?: {
+    comment?: string | null;
+    deleteBranch?: boolean;
+  }
+): Promise<void> {
+  const args = ["pr", "close", String(prNumber)];
+
+  if (options?.comment?.trim()) {
+    args.push("--comment", options.comment.trim());
+  }
+
+  if (options?.deleteBranch) {
+    args.push("--delete-branch");
+  }
+
+  await runGh(args, { cwd: repoPath });
+}
+
 export function resolveRepoPath(repoPath: string): string {
   return path.resolve(repoPath);
 }

--- a/packages/core/src/runtime-state.ts
+++ b/packages/core/src/runtime-state.ts
@@ -5,6 +5,7 @@ import type {
   ConversationMessageRecord,
   ConversationThreadRecord,
   OrchestratorStatus,
+  PrSweepStatus,
   RunRecord
 } from "@director-os/shared";
 
@@ -59,6 +60,20 @@ export interface RouterHandoffState {
   updatedAt: string;
 }
 
+export interface RouterPrSweepState {
+  status: PrSweepStatus;
+  nextRunAt: string | null;
+  currentPullRequestNumber: number | null;
+  pendingPullRequestNumbers: number[];
+  blockerIssueNumbers: number[];
+  waitingOnIssueNumber: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  lastSummary: string | null;
+  pausedIssueWork: boolean;
+  updatedAt: string | null;
+}
+
 export interface RouterState {
   version: number;
   projectSlug: string;
@@ -76,6 +91,7 @@ export interface RouterState {
   lanes: RouterLaneState[];
   issueOwnership: Record<string, string>;
   pendingHandoffs: RouterHandoffState[];
+  prSweep: RouterPrSweepState;
   openQuestion: RouterQuestionState | null;
   recentRuns: RunRecord[];
   lastSyncAt: string | null;
@@ -163,6 +179,19 @@ export function createDefaultRouterState(projectSlug: string): RouterState {
     lanes: [],
     issueOwnership: {},
     pendingHandoffs: [],
+    prSweep: {
+      status: "idle",
+      nextRunAt: null,
+      currentPullRequestNumber: null,
+      pendingPullRequestNumbers: [],
+      blockerIssueNumbers: [],
+      waitingOnIssueNumber: null,
+      startedAt: null,
+      completedAt: null,
+      lastSummary: "Chief of Staff will schedule PR sweeps as needed.",
+      pausedIssueWork: false,
+      updatedAt: timestamp
+    },
     openQuestion: null,
     recentRuns: [],
     lastSyncAt: null,
@@ -259,6 +288,16 @@ export async function loadRouterState(paths: RuntimePaths, projectSlug: string):
           details: handoff.details ?? null
         }))
       : [],
+    prSweep: {
+      ...fallback.prSweep,
+      ...(state as Partial<RouterState>).prSweep,
+      pendingPullRequestNumbers: Array.isArray(state.prSweep?.pendingPullRequestNumbers)
+        ? state.prSweep.pendingPullRequestNumbers
+        : [],
+      blockerIssueNumbers: Array.isArray(state.prSweep?.blockerIssueNumbers)
+        ? state.prSweep.blockerIssueNumbers
+        : []
+    },
     recentRuns: Array.isArray(state.recentRuns) ? state.recentRuns : []
   };
 }

--- a/packages/core/src/services.test.ts
+++ b/packages/core/src/services.test.ts
@@ -6,14 +6,25 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import type { DecisionRecord, ProjectRecord, RunRecord } from "@director-os/shared";
+import type {
+  DecisionRecord,
+  GitHubIssueRecord,
+  ProjectRecord,
+  RunRecord
+} from "@director-os/shared";
 import type { StoredProjectConfig } from "./config.js";
 import { createDefaultRouterState, type RouterState } from "./runtime-state.js";
 import {
+  buildPrSweepBlockerLabels,
   buildResetRouterState,
   ensureIssueWorktree,
+  isPrSweepDue,
   reconcileProjectConfigWithRepository,
-  resolveLastSuccessfulSyncAt
+  resolveLastSuccessfulSyncAt,
+  schedulePrSweepState,
+  sortQueueableIssues,
+  startPrSweepState,
+  updateRunningPrSweepState
 } from "./services.js";
 
 const execFileAsync = promisify(execFile);
@@ -120,6 +131,26 @@ function makeDecisionRecord(overrides: Partial<DecisionRecord> = {}): DecisionRe
     resolution: null,
     createdAt: "2026-04-06T00:00:00.000Z",
     updatedAt: "2026-04-06T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+function makeIssueRecord(
+  number: number,
+  overrides: Partial<GitHubIssueRecord> = {}
+): GitHubIssueRecord {
+  return {
+    id: number,
+    projectId: 1,
+    number,
+    title: `Issue #${number}`,
+    body: "",
+    state: "open",
+    workflowState: "ready",
+    labels: [],
+    url: `https://github.com/njuneja27/director-os/issues/${number}`,
+    updatedAt: "2026-04-06T00:00:00.000Z",
+    syncedAt: "2026-04-06T00:00:00.000Z",
     ...overrides
   };
 }
@@ -247,6 +278,115 @@ describe("ensureIssueWorktree", () => {
   });
 });
 
+describe("PR sweep helpers", () => {
+  it("prioritizes blocker issues ahead of the normal issue queue", () => {
+    const ordered = sortQueueableIssues([
+      makeIssueRecord(40, {
+        workflowState: "queued"
+      }),
+      makeIssueRecord(10, {
+        workflowState: "queued",
+        labels: ["director:priority"]
+      }),
+      makeIssueRecord(20),
+      makeIssueRecord(30, {
+        labels: ["director:priority"]
+      })
+    ]);
+
+    expect(ordered.map((issue) => issue.number)).toEqual([30, 10, 20, 40]);
+  });
+
+  it("schedules the next PR sweep and preserves blocker visibility", () => {
+    const nowMs = Date.parse("2026-04-06T14:00:00.000Z");
+    const state = schedulePrSweepState(
+      {
+        ...createDefaultRouterState("director-os").prSweep,
+        blockerIssueNumbers: [98]
+      },
+      2,
+      "Next PR sweep scheduled.",
+      nowMs
+    );
+
+    expect(state.status).toBe("scheduled");
+    expect(state.nextRunAt).toBe("2026-04-06T16:00:00.000Z");
+    expect(state.waitingOnIssueNumber).toBe(98);
+    expect(state.pausedIssueWork).toBe(false);
+    expect(state.pendingPullRequestNumbers).toEqual([]);
+    expect(state.lastSummary).toBe("Next PR sweep scheduled.");
+  });
+
+  it("marks sweep runs as active and steps pending PRs down as each review starts", () => {
+    const started = startPrSweepState(createDefaultRouterState("director-os").prSweep, [83, 84, 85], {
+      now: "2026-04-06T14:05:00.000Z"
+    });
+    const updated = updateRunningPrSweepState(started, {
+      currentPullRequestNumber: 83,
+      removePullRequestNumber: 83,
+      blockerIssueNumber: 112,
+      waitingOnIssueNumber: 112,
+      summary: "Opened blocker issue #112 while reviewing PR #83.",
+      now: "2026-04-06T14:06:00.000Z"
+    });
+
+    expect(started.status).toBe("running");
+    expect(started.pendingPullRequestNumbers).toEqual([83, 84, 85]);
+    expect(started.pausedIssueWork).toBe(true);
+    expect(updated.currentPullRequestNumber).toBe(83);
+    expect(updated.pendingPullRequestNumbers).toEqual([84, 85]);
+    expect(updated.blockerIssueNumbers).toEqual([112]);
+    expect(updated.waitingOnIssueNumber).toBe(112);
+    expect(updated.lastSummary).toBe("Opened blocker issue #112 while reviewing PR #83.");
+  });
+
+  it("treats running sweeps and overdue scheduled sweeps as immediately due", () => {
+    const nowMs = Date.parse("2026-04-06T14:00:00.000Z");
+
+    expect(
+      isPrSweepDue(
+        {
+          status: "running",
+          nextRunAt: null
+        },
+        nowMs
+      )
+    ).toBe(true);
+
+    expect(
+      isPrSweepDue(
+        {
+          status: "scheduled",
+          nextRunAt: "2026-04-06T13:59:00.000Z"
+        },
+        nowMs
+      )
+    ).toBe(true);
+
+    expect(
+      isPrSweepDue(
+        {
+          status: "scheduled",
+          nextRunAt: "2026-04-06T14:01:00.000Z"
+        },
+        nowMs
+      )
+    ).toBe(false);
+  });
+
+  it("labels PR sweep blocker issues for priority routing and lane ownership", () => {
+    expect(buildPrSweepBlockerLabels("experience")).toEqual([
+      "director:ready",
+      "director:priority",
+      "director:lane:experience"
+    ]);
+    expect(buildPrSweepBlockerLabels("")).toEqual([
+      "director:ready",
+      "director:priority"
+    ]);
+  });
+});
+
 describe("resolveLastSuccessfulSyncAt", () => {
   it("falls back to the GitHub cache timestamp when router state has not recorded one yet", () => {
     expect(
@@ -326,6 +466,19 @@ describe("buildResetRouterState", () => {
           updatedAt: "2026-04-06T12:27:00.000Z"
         }
       ],
+      prSweep: {
+        status: "running",
+        nextRunAt: "2026-04-06T12:35:00.000Z",
+        currentPullRequestNumber: 95,
+        pendingPullRequestNumbers: [96],
+        blockerIssueNumbers: [82],
+        waitingOnIssueNumber: 82,
+        startedAt: "2026-04-06T12:21:00.000Z",
+        completedAt: "2026-04-06T11:40:00.000Z",
+        lastSummary: "PR sweep is waiting on issue #82 before it resumes backlog work.",
+        pausedIssueWork: true,
+        updatedAt: "2026-04-06T12:29:30.000Z"
+      },
       openQuestion: {
         id: "question_1",
         title: "Need runtime recovery decision",
@@ -382,6 +535,13 @@ describe("buildResetRouterState", () => {
     expect(reset.lanes).toEqual([]);
     expect(reset.issueOwnership).toEqual({});
     expect(reset.pendingHandoffs).toEqual([]);
+    expect(reset.prSweep.status).toBe("idle");
+    expect(reset.prSweep.nextRunAt).toBeNull();
+    expect(reset.prSweep.currentPullRequestNumber).toBeNull();
+    expect(reset.prSweep.pendingPullRequestNumbers).toEqual([]);
+    expect(reset.prSweep.blockerIssueNumbers).toEqual([]);
+    expect(reset.prSweep.waitingOnIssueNumber).toBeNull();
+    expect(reset.prSweep.pausedIssueWork).toBe(false);
     expect(reset.openQuestion).toBeNull();
     expect(reset.recentRuns).toEqual([]);
   });

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -18,7 +18,6 @@ import type {
   IssueOwnershipRecord,
   LaneRecord,
   OrchestratorStatusRecord,
-  PrCycleRecord,
   ProjectRecord,
   RunRecord,
   SetupCheck,
@@ -49,6 +48,7 @@ import {
 } from "./config.js";
 import { COS_TASK_APPENDICES, buildChiefOfStaffPrompt } from "./cos.js";
 import {
+  closePullRequest,
   commentOnIssue,
   createIssue,
   createPullRequest,
@@ -58,8 +58,11 @@ import {
   listComments,
   listIssues,
   listPullRequests,
+  mergePullRequest,
   probeGhCli,
   probeRepositoryPath,
+  pullRequestChecks,
+  pullRequestDiff,
   resolveRepoPath,
   viewPullRequest
 } from "./github.js";
@@ -95,6 +98,11 @@ const execFileAsync = promisify(execFile);
 const LOOP_INTERVAL_MS = 30 * 1000;
 const ORCHESTRATOR_OWNER_TOKEN = `${process.pid}:${randomUUID()}`;
 const CHIEF_OF_STAFF_OWNER_ID = "chief_of_staff";
+const PR_SWEEP_PRIORITY_LABEL = "director:priority";
+const PR_SWEEP_DEFAULT_INTERVAL_HOURS = 4;
+const PR_SWEEP_IDLE_INTERVAL_HOURS = 24;
+const PR_SWEEP_MAX_DIFF_LENGTH = 12_000;
+const PR_SWEEP_MAX_COMMENTS = 12;
 const RESET_ROUTER_RUNTIME_SUMMARY =
   "Local router runtime reset. Sync GitHub, then restart the Chief of Staff loop.";
 const RESET_ROUTER_RUNTIME_CLEARED = [
@@ -264,6 +272,157 @@ function parseDataString(value: unknown): string | null {
 
 function parseDataNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseIntervalHours(value: unknown): number | null {
+  const numeric = parseDataNumber(value);
+  if (numeric === null) {
+    return null;
+  }
+
+  return numeric >= 0 ? Math.min(Math.floor(numeric), 168) : null;
+}
+
+export function hasPriorityLabel(
+  issue: Pick<GitHubIssueRecord, "labels">
+): boolean {
+  return issue.labels.includes(PR_SWEEP_PRIORITY_LABEL);
+}
+
+export function sortQueueableIssues(
+  issues: GitHubIssueRecord[]
+): GitHubIssueRecord[] {
+  return [...issues].sort((left, right) => {
+    const leftPriority = hasPriorityLabel(left) ? 0 : 1;
+    const rightPriority = hasPriorityLabel(right) ? 0 : 1;
+    const leftWorkflow = left.workflowState === "ready" ? 0 : 1;
+    const rightWorkflow = right.workflowState === "ready" ? 0 : 1;
+
+    return leftPriority - rightPriority || leftWorkflow - rightWorkflow || left.number - right.number;
+  });
+}
+
+export function computePrSweepNextRunAt(
+  intervalHours: number,
+  nowMs = Date.now()
+): string {
+  return new Date(nowMs + Math.max(0, intervalHours) * 60 * 60 * 1000).toISOString();
+}
+
+export function schedulePrSweepState(
+  prSweep: RouterState["prSweep"],
+  intervalHours: number,
+  summary: string,
+  nowMs = Date.now()
+): RouterState["prSweep"] {
+  const timestamp = new Date(nowMs).toISOString();
+
+  return {
+    ...prSweep,
+    status: "scheduled",
+    nextRunAt: computePrSweepNextRunAt(intervalHours, nowMs),
+    currentPullRequestNumber: null,
+    pendingPullRequestNumbers: [],
+    waitingOnIssueNumber: prSweep.blockerIssueNumbers[0] ?? null,
+    completedAt: timestamp,
+    lastSummary: summary,
+    pausedIssueWork: false,
+    updatedAt: timestamp
+  };
+}
+
+export function startPrSweepState(
+  prSweep: RouterState["prSweep"],
+  pullRequestNumbers: number[],
+  options?: {
+    summary?: string | null;
+    now?: string;
+  }
+): RouterState["prSweep"] {
+  const timestamp = options?.now ?? nowIso();
+
+  return {
+    ...prSweep,
+    status: "running",
+    nextRunAt: null,
+    currentPullRequestNumber: null,
+    pendingPullRequestNumbers: [...pullRequestNumbers],
+    blockerIssueNumbers: [],
+    waitingOnIssueNumber: null,
+    startedAt: timestamp,
+    lastSummary:
+      options?.summary ??
+      (pullRequestNumbers.length > 0
+        ? `Chief of Staff started a PR sweep across ${pullRequestNumbers.length} open pull request${
+            pullRequestNumbers.length === 1 ? "" : "s"
+          }.`
+        : "Chief of Staff started a PR sweep with no open pull requests."),
+    pausedIssueWork: true,
+    updatedAt: timestamp
+  };
+}
+
+export function updateRunningPrSweepState(
+  prSweep: RouterState["prSweep"],
+  input: {
+    currentPullRequestNumber?: number | null;
+    removePullRequestNumber?: number | null;
+    blockerIssueNumber?: number | null;
+    waitingOnIssueNumber?: number | null;
+    summary?: string | null;
+    now?: string;
+  }
+): RouterState["prSweep"] {
+  const timestamp = input.now ?? nowIso();
+  const nextPending =
+    input.removePullRequestNumber === null || input.removePullRequestNumber === undefined
+      ? prSweep.pendingPullRequestNumbers
+      : prSweep.pendingPullRequestNumbers.filter((number) => number !== input.removePullRequestNumber);
+  const nextBlockers =
+    input.blockerIssueNumber === null || input.blockerIssueNumber === undefined
+      ? prSweep.blockerIssueNumbers
+      : [...prSweep.blockerIssueNumbers, input.blockerIssueNumber];
+
+  return {
+    ...prSweep,
+    status: "running",
+    currentPullRequestNumber:
+      input.currentPullRequestNumber === undefined
+        ? prSweep.currentPullRequestNumber
+        : input.currentPullRequestNumber,
+    pendingPullRequestNumbers: nextPending,
+    blockerIssueNumbers: nextBlockers,
+    waitingOnIssueNumber:
+      input.waitingOnIssueNumber === undefined
+        ? prSweep.waitingOnIssueNumber
+        : input.waitingOnIssueNumber,
+    lastSummary: input.summary ?? prSweep.lastSummary,
+    pausedIssueWork: true,
+    updatedAt: timestamp
+  };
+}
+
+export function isPrSweepDue(
+  prSweep: Pick<RouterState["prSweep"], "status" | "nextRunAt">,
+  nowMs = Date.now()
+): boolean {
+  if (prSweep.status === "running") {
+    return true;
+  }
+
+  return Boolean(prSweep.nextRunAt && Date.parse(prSweep.nextRunAt) <= nowMs);
+}
+
+export function buildPrSweepBlockerLabels(laneId?: string | null): string[] {
+  return [
+    "director:ready",
+    PR_SWEEP_PRIORITY_LABEL,
+    laneId?.trim() ? `director:lane:${laneId.trim()}` : null
+  ].filter((label): label is string => Boolean(label));
+}
+
+function prSweepIntervalHoursForOpenPrCount(openPullRequestCount: number): number {
+  return openPullRequestCount > 0 ? PR_SWEEP_DEFAULT_INTERVAL_HOURS : PR_SWEEP_IDLE_INTERVAL_HOURS;
 }
 
 function labelsForIssueTask(task: ProposedIssueTask): string[] {
@@ -1264,6 +1423,23 @@ async function resolveFreshIssueWorktreeTarget(
   }
 }
 
+async function resolveFreshDetachedWorktreePath(
+  entries: Awaited<ReturnType<typeof listGitWorktrees>>,
+  desiredWorktreePath: string
+): Promise<string> {
+  const livePaths = new Set(entries.filter((entry) => !entry.isPrunable).map((entry) => entry.path));
+
+  let attempt = 0;
+  while (true) {
+    const candidateWorktreePath = suffixedWorktreeTarget(desiredWorktreePath, attempt);
+    if (!livePaths.has(candidateWorktreePath)) {
+      return candidateWorktreePath;
+    }
+
+    attempt += 1;
+  }
+}
+
 async function ensureWorktreeNodeModules(
   project: ProjectRecord,
   worktreePath: string
@@ -1392,6 +1568,68 @@ export async function ensureIssueWorktree(
   return {
     branchName: target.branchName,
     worktreePath: target.worktreePath
+  };
+}
+
+async function ensurePullRequestWorktree(
+  project: ProjectRecord,
+  pullRequest: GitHubPullRequestRecord
+): Promise<{
+  branchName: string;
+  worktreePath: string;
+  pushBranchName: string;
+}> {
+  await fs.mkdir(project.worktreeRoot, { recursive: true });
+  await pruneGitWorktrees(project.repoPath);
+
+  const [worktreeRootComparablePath, rawEntries] = await Promise.all([
+    resolveComparablePath(project.worktreeRoot),
+    listGitWorktrees(project.repoPath)
+  ]);
+
+  const entries = (
+    await Promise.all(
+      rawEntries.map(async (entry) => ({
+        entry,
+        comparablePath: await resolveComparablePath(entry.path)
+      }))
+    )
+  )
+    .filter(({ comparablePath }) => comparablePath.startsWith(`${worktreeRootComparablePath}${path.sep}`))
+    .map(({ entry }) => entry);
+
+  const desiredWorktreePath = path.join(project.worktreeRoot, `pr-${pullRequest.number}`);
+  const worktreePath = await resolveFreshDetachedWorktreePath(entries, desiredWorktreePath);
+
+  if (await pathExists(worktreePath)) {
+    await fs.rm(worktreePath, { recursive: true, force: true });
+  }
+
+  await runCommandOrThrow(
+    "git",
+    ["-C", project.repoPath, "fetch", "origin", pullRequest.headRefName],
+    { cwd: project.repoPath }
+  );
+  await runCommandOrThrow(
+    "git",
+    [
+      "-C",
+      project.repoPath,
+      "worktree",
+      "add",
+      "--detach",
+      worktreePath,
+      `origin/${pullRequest.headRefName}`
+    ],
+    { cwd: project.repoPath }
+  );
+
+  await ensureWorktreeNodeModules(project, worktreePath);
+
+  return {
+    branchName: pullRequest.headRefName,
+    worktreePath,
+    pushBranchName: pullRequest.headRefName
   };
 }
 
@@ -1683,6 +1921,22 @@ function synthesizeActivity(router: RouterState): ActivityRecord[] {
   return [...questionActivity, ...runActivity]
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
     .slice(0, 12);
+}
+
+function synthesizePrSweepRecord(router: RouterState): DirectorStatusResponse["prSweep"] {
+  return {
+    status: router.prSweep.status,
+    nextRunAt: router.prSweep.nextRunAt,
+    currentPullRequestNumber: router.prSweep.currentPullRequestNumber,
+    pendingPullRequestNumbers: router.prSweep.pendingPullRequestNumbers,
+    blockerIssueNumbers: router.prSweep.blockerIssueNumbers,
+    waitingOnIssueNumber: router.prSweep.waitingOnIssueNumber,
+    startedAt: router.prSweep.startedAt,
+    completedAt: router.prSweep.completedAt,
+    lastSummary: router.prSweep.lastSummary,
+    pausedIssueWork: router.prSweep.pausedIssueWork,
+    updatedAt: router.prSweep.updatedAt
+  };
 }
 
 function synthesizeOrchestratorStatus(
@@ -2074,6 +2328,860 @@ async function createIssuesFromPlan(
   return created;
 }
 
+function openPullRequestsFromCache(
+  session: ProjectSession,
+  cache: GitHubCacheState
+): GitHubPullRequestRecord[] {
+  return cache.pullRequests
+    .map((pullRequest) => mapRemotePullRequest(session.project, pullRequest, cache.syncedAt))
+    .filter((pullRequest) => pullRequest.state.toLowerCase() === "open")
+    .sort((left, right) => left.number - right.number);
+}
+
+function linkedIssueForPullRequest(
+  session: ProjectSession,
+  cache: GitHubCacheState,
+  pullRequest: GitHubPullRequestRecord
+): GitHubIssueRecord | null {
+  const linkedIssueNumber = pullRequest.linkedIssueNumbers[0] ?? null;
+  if (!linkedIssueNumber) {
+    return null;
+  }
+
+  return (
+    cache.issues
+      .map((issue) => mapRemoteIssue(session.project, issue))
+      .find((issue) => issue.number === linkedIssueNumber) ?? null
+  );
+}
+
+function summarizePullRequestChecks(
+  checks: Awaited<ReturnType<typeof pullRequestChecks>>
+): string {
+  if (!checks.length) {
+    return "No GitHub check results were reported.";
+  }
+
+  return checks
+    .map((check) => {
+      const workflow = check.workflow?.trim() ? ` (${check.workflow.trim()})` : "";
+      return `- ${check.name}: ${check.state}${workflow}`;
+    })
+    .join("\n");
+}
+
+function summarizePullRequestComments(
+  comments: GitHubCacheState["comments"]
+): string {
+  if (!comments.length) {
+    return "No recent PR comments were synced.";
+  }
+
+  return comments
+    .slice(-PR_SWEEP_MAX_COMMENTS)
+    .map((comment) => {
+      const excerpt = summarizeText(comment.body, 400);
+      return `- [${comment.author}] ${excerpt}`;
+    })
+    .join("\n");
+}
+
+function buildPrSweepSchedulePrompt(
+  router: RouterState,
+  openPullRequests: GitHubPullRequestRecord[],
+  issues: GitHubIssueRecord[]
+): string {
+  return buildChiefOfStaffPrompt(COS_TASK_APPENDICES.planPrSweep, [
+    {
+      title: "Current open pull requests",
+      content:
+        openPullRequests.length > 0
+          ? openPullRequests
+              .map(
+                (pullRequest) =>
+                  `- PR #${pullRequest.number} ${pullRequest.title} (${pullRequest.reviewDecision ?? pullRequest.checksBucket ?? "open"})`
+              )
+              .join("\n")
+          : "No open pull requests are currently queued."
+    },
+    {
+      title: "Ready issue queue",
+      content:
+        issues.length > 0
+          ? sortQueueableIssues(issues)
+              .slice(0, 12)
+              .map((issue) => {
+                const priorityFlag = hasPriorityLabel(issue) ? " priority" : "";
+                return `- #${issue.number} [${issue.workflowState}${priorityFlag}] ${issue.title}`;
+              })
+              .join("\n")
+          : "No queueable issues are mirrored right now."
+    },
+    {
+      title: "Existing PR sweep state",
+      content: [
+        `Status: ${router.prSweep.status}`,
+        router.prSweep.nextRunAt ? `Next run at: ${router.prSweep.nextRunAt}` : "Next run at: unscheduled",
+        router.prSweep.completedAt ? `Last completed at: ${router.prSweep.completedAt}` : null,
+        router.prSweep.lastSummary ? `Last summary: ${router.prSweep.lastSummary}` : null
+      ]
+        .filter(Boolean)
+        .join("\n")
+    }
+  ]);
+}
+
+function buildPullRequestReviewPrompt(
+  pullRequest: GitHubPullRequestRecord,
+  linkedIssue: GitHubIssueRecord | null,
+  checks: Awaited<ReturnType<typeof pullRequestChecks>>,
+  comments: GitHubCacheState["comments"],
+  diff: string
+): string {
+  return buildChiefOfStaffPrompt(COS_TASK_APPENDICES.reviewPr, [
+    {
+      title: "Linked issue",
+      content: linkedIssue
+        ? `#${linkedIssue.number} ${linkedIssue.title}\n${linkedIssue.body.trim() || "No issue body provided."}`
+        : "No linked GitHub issue was detected from the PR closing references."
+    },
+    {
+      title: "Pull request",
+      content: [
+        `PR #${pullRequest.number} ${pullRequest.title}`,
+        `Head -> base: ${pullRequest.headRefName} -> ${pullRequest.baseRefName}`,
+        `Review decision: ${pullRequest.reviewDecision ?? "none"}`,
+        `Checks bucket: ${pullRequest.checksBucket ?? "unknown"}`,
+        "",
+        pullRequest.body.trim() || "No pull request body provided."
+      ].join("\n")
+    },
+    {
+      title: "GitHub checks",
+      content: summarizePullRequestChecks(checks)
+    },
+    {
+      title: "Recent PR comments",
+      content: summarizePullRequestComments(comments)
+    },
+    {
+      title: "Diff excerpt",
+      content: truncatePromptSection(diff, PR_SWEEP_MAX_DIFF_LENGTH) ?? "No diff was available."
+    }
+  ]);
+}
+
+function buildPullRequestRefinementPrompt(input: {
+  lane: RouterLaneState;
+  issue: GitHubIssueRecord;
+  pullRequest: GitHubPullRequestRecord;
+  worktreePath: string;
+  branchName: string;
+  feedback: string;
+  checks: Awaited<ReturnType<typeof pullRequestChecks>>;
+  comments: GitHubCacheState["comments"];
+  diff: string;
+}): string {
+  return [
+    "You are a persistent lane Codex session owned by the Chief of Staff in Director OS.",
+    "Stay within your lane context. Do not address the human directly.",
+    "Task: refine an existing pull request branch so it is ready to merge to main.",
+    "Return structured output only.",
+    "Work only inside the assigned worktree path.",
+    "If you are blocked on a true product or taste judgment, set `status` to `needs_input` and put the exact blocker in `blocking_questions`.",
+    "Otherwise make the required code changes, leave the branch ready for validation, and summarize what changed in `data.transcript_reply`.",
+    "",
+    `Lane: ${input.lane.name} (${input.lane.id})`,
+    `Issue: #${input.issue.number} ${input.issue.title}`,
+    `Pull request: #${input.pullRequest.number} ${input.pullRequest.title}`,
+    `Assigned branch: ${input.branchName}`,
+    `Assigned worktree: ${input.worktreePath}`,
+    "",
+    "Chief of Staff feedback to address:",
+    input.feedback,
+    "",
+    "GitHub checks:",
+    summarizePullRequestChecks(input.checks),
+    "",
+    "Recent PR comments:",
+    summarizePullRequestComments(input.comments),
+    "",
+    "Diff excerpt:",
+    truncatePromptSection(input.diff, PR_SWEEP_MAX_DIFF_LENGTH) ?? "No diff was available.",
+    "",
+    "Issue body:",
+    input.issue.body.trim() || "No issue body provided."
+  ]
+    .concat(
+      input.lane.lastPlanSummary ? ["", "Existing lane plan summary:", input.lane.lastPlanSummary] : [],
+      input.lane.lastSummary ? ["", "Latest lane summary:", input.lane.lastSummary] : []
+    )
+    .join("\n");
+}
+
+function summarizePrSweepRun(stats: {
+  reviewed: number;
+  merged: number;
+  fixedAndMerged: number;
+  closed: number;
+  blockerIssues: number;
+  escalations: number;
+}): string {
+  return [
+    `Reviewed ${stats.reviewed} PR${stats.reviewed === 1 ? "" : "s"}.`,
+    `Merged ${stats.merged}.`,
+    stats.fixedAndMerged > 0 ? `Fixed and merged ${stats.fixedAndMerged}.` : null,
+    stats.closed > 0 ? `Closed ${stats.closed}.` : null,
+    stats.blockerIssues > 0 ? `Opened ${stats.blockerIssues} blocker issue${stats.blockerIssues === 1 ? "" : "s"}.` : null,
+    stats.escalations > 0 ? `Waiting on ${stats.escalations} human decision${stats.escalations === 1 ? "" : "s"}.` : null
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+async function savePrSweepState(
+  session: ProjectSession,
+  updater: (router: RouterState) => RouterState
+): Promise<RouterState> {
+  const router = await loadRouterState(session.paths, session.project.slug);
+  const nextRouter = updater(router);
+  nextRouter.prSweep.updatedAt = nowIso();
+  return saveRouterState(session.paths, nextRouter);
+}
+
+async function scheduleNextPrSweep(
+  session: ProjectSession,
+  router: RouterState,
+  cache: GitHubCacheState,
+  options?: {
+    completedAt?: string | null;
+    lastSummary?: string | null;
+  }
+): Promise<RouterState> {
+  const openPullRequests = openPullRequestsFromCache(session, cache);
+  const queueableIssues = cache.issues
+    .map((issue) => mapRemoteIssue(session.project, issue))
+    .filter((issue) => issue.state.toLowerCase() === "open")
+    .filter((issue) => issue.workflowState === "ready" || issue.workflowState === "queued");
+  const prompt = buildPrSweepSchedulePrompt(router, openPullRequests, queueableIssues);
+  const defaultIntervalHours: number =
+    openPullRequests.length > 0 && !router.prSweep.completedAt
+      ? 0
+      : prSweepIntervalHoursForOpenPrCount(openPullRequests.length);
+
+  const turn = await runCodexSessionAgent(
+    {
+      role: "chief_of_staff",
+      cwd: session.project.repoPath,
+      model: session.project.model,
+      allowWrite: false,
+      prompt,
+      sessionId: router.chiefOfStaff.sessionId
+    },
+    {
+      status: "ok",
+      summary: "Scheduled the next PR sweep window.",
+      recommended_next_action: "Continue routing work until the next PR sweep window arrives.",
+      artifact_refs: [],
+      blocking_questions: [],
+      data: {
+        pr_sweep_interval_hours: defaultIntervalHours,
+        transcript_reply:
+          defaultIntervalHours === 0
+            ? "The next PR sweep should run immediately."
+            : `The next PR sweep should run in ${defaultIntervalHours} hour${defaultIntervalHours === 1 ? "" : "s"}.`
+      }
+    }
+  );
+
+  const intervalHours = parseIntervalHours(turn.result.data?.pr_sweep_interval_hours) ?? defaultIntervalHours;
+  const nextRunAt = computePrSweepNextRunAt(intervalHours);
+  const scheduleSummary =
+    parseDataString(turn.result.data?.transcript_reply) ??
+    (intervalHours === 0
+      ? "The next PR sweep should run immediately."
+      : `The next PR sweep should run in ${intervalHours} hour${intervalHours === 1 ? "" : "s"}.`);
+
+  const nextRouter = applyChiefOfStaffTurn(session, router, {
+    sessionId: turn.sessionId,
+    phase: "pr_sweep_schedule",
+    result: turn.result
+  });
+
+  nextRouter.prSweep = {
+    ...nextRouter.prSweep,
+    status: "scheduled",
+    nextRunAt,
+    currentPullRequestNumber: null,
+    completedAt: options?.completedAt ?? nextRouter.prSweep.completedAt,
+    lastSummary: [options?.lastSummary, `Next PR sweep at ${nextRunAt}.`, scheduleSummary]
+      .filter(Boolean)
+      .join(" "),
+    pausedIssueWork: false,
+    updatedAt: nowIso()
+  };
+
+  return saveRouterState(session.paths, nextRouter);
+}
+
+async function createPrSweepBlockerIssue(
+  session: ProjectSession,
+  router: RouterState,
+  pullRequest: GitHubPullRequestRecord,
+  linkedIssue: GitHubIssueRecord | null,
+  options: {
+    feedback: string;
+    task?: ProposedIssueTask | null;
+  }
+): Promise<{ number: number; title: string; url: string }> {
+  const laneId =
+    findIssueLane(router, linkedIssue?.number ?? -1)?.id ??
+    (linkedIssue ? defaultLaneForIssue(linkedIssue).id : null);
+  const task = options.task;
+  const title = task?.title ?? `Stabilize PR #${pullRequest.number} before merge`;
+  const body = [
+    task?.body ??
+      [
+        `PR #${pullRequest.number} (${pullRequest.title}) could not be safely merged in the automated PR sweep.`,
+        options.feedback
+      ].join("\n\n"),
+    "",
+    `Blocked pull request: #${pullRequest.number}`,
+    `PR URL: ${pullRequest.url}`,
+    linkedIssue ? `Linked issue: #${linkedIssue.number}` : null
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const issue = await createIssue(session.project.repoSlug, {
+    title,
+    body,
+    labels: buildPrSweepBlockerLabels(laneId)
+  });
+
+  return {
+    number: issue.number,
+    title,
+    url: issue.url
+  };
+}
+
+async function reviewPullRequestInSweep(
+  session: ProjectSession,
+  router: RouterState,
+  cache: GitHubCacheState,
+  pullRequest: GitHubPullRequestRecord
+): Promise<{
+  router: RouterState;
+  decision: string;
+  feedback: string | null;
+  linkedIssue: GitHubIssueRecord | null;
+  issueTasks: ProposedIssueTask[];
+  transcriptReply: string | null;
+}> {
+  const linkedIssue = linkedIssueForPullRequest(session, cache, pullRequest);
+  const [checks, diff] = await Promise.all([
+    pullRequestChecks(session.project.repoPath, pullRequest.number).catch(() => []),
+    pullRequestDiff(session.project.repoPath, pullRequest.number).catch(
+      (error) => `Could not load PR diff: ${error instanceof Error ? error.message : String(error)}`
+    )
+  ]);
+  const comments = cache.comments.filter(
+    (comment) => comment.parentType === "pr" && comment.parentNumber === pullRequest.number
+  );
+  const prompt = buildPullRequestReviewPrompt(
+    pullRequest,
+    linkedIssue,
+    checks,
+    comments,
+    diff
+  );
+  const fallbackDecision = pullRequest.reviewDecision === "CHANGES_REQUESTED" ? "changes" : "merge";
+  const turn = await runCodexSessionAgent(
+    {
+      role: "chief_of_staff",
+      cwd: session.project.repoPath,
+      model: session.project.model,
+      allowWrite: false,
+      prompt,
+      sessionId: router.chiefOfStaff.sessionId
+    },
+    {
+      status: "ok",
+      summary: `Reviewed PR #${pullRequest.number}.`,
+      recommended_next_action:
+        fallbackDecision === "merge"
+          ? "Merge the pull request if no new blocker surfaced."
+          : "Refine the pull request branch before merging.",
+      artifact_refs: [],
+      blocking_questions: [],
+      data: {
+        decision: fallbackDecision,
+        feedback:
+          fallbackDecision === "changes"
+            ? "Address the current review or validation concerns before merging."
+            : null,
+        transcript_reply: `Reviewed PR #${pullRequest.number}.`
+      }
+    }
+  );
+
+  const nextRouter = applyChiefOfStaffTurn(session, router, {
+    sessionId: turn.sessionId,
+    phase: "pr_sweep_review",
+    result: turn.result,
+    issueNumber: linkedIssue?.number ?? null,
+    prNumber: pullRequest.number
+  });
+  await saveRouterState(session.paths, nextRouter);
+
+  return {
+    router: nextRouter,
+    decision: parseDataString(turn.result.data?.decision) ?? fallbackDecision,
+    feedback: parseDataString(turn.result.data?.feedback),
+    linkedIssue,
+    issueTasks: parseProposedIssueTasks(turn.result.data?.new_issues),
+    transcriptReply: parseDataString(turn.result.data?.transcript_reply)
+  };
+}
+
+async function refinePullRequestInSweep(
+  session: ProjectSession,
+  router: RouterState,
+  linkedIssue: GitHubIssueRecord,
+  pullRequest: GitHubPullRequestRecord,
+  feedback: string
+): Promise<"merged" | "blocker_issue"> {
+  const laneFallback = findIssueLane(router, linkedIssue.number) ?? null;
+  const laneDescriptor = laneFallback ?? {
+    id: defaultLaneForIssue(linkedIssue).id,
+    name: defaultLaneForIssue(linkedIssue).name,
+    sessionId: null,
+    issueNumbers: [],
+    status: "idle" as const,
+    currentIssueNumber: null,
+    activePullRequestNumber: null,
+    lastSummary: null,
+    lastPlanSummary: null,
+    updatedAt: nowIso()
+  };
+
+  await savePrSweepState(session, (nextRouter) => {
+    assignIssueToLane(nextRouter, linkedIssue.number, laneDescriptor.id, laneDescriptor.name);
+    return nextRouter;
+  });
+
+  const worktree = await ensureIssueWorktree(
+    session.project,
+    linkedIssue.number,
+    pullRequest.headRefName,
+    path.join(session.project.worktreeRoot, `issue-${linkedIssue.number}`),
+    {
+      preserveExistingBranch: true
+    }
+  );
+
+  const cache = await loadGitHubCacheState(session.paths, session.project.slug);
+  const liveLaneRouter = await loadRouterState(session.paths, session.project.slug);
+  const lane = ensureLane(liveLaneRouter, laneDescriptor.id, laneDescriptor.name);
+  const [checks, diff] = await Promise.all([
+    pullRequestChecks(session.project.repoPath, pullRequest.number).catch(() => []),
+    pullRequestDiff(session.project.repoPath, pullRequest.number).catch(
+      (error) => `Could not load PR diff: ${error instanceof Error ? error.message : String(error)}`
+    )
+  ]);
+  const comments = cache.comments.filter(
+    (comment) => comment.parentType === "pr" && comment.parentNumber === pullRequest.number
+  );
+
+  const turn = await runCodexSessionAgent(
+    {
+      role: "lane_owner",
+      cwd: worktree.worktreePath,
+      model: session.project.model,
+      allowWrite: true,
+      prompt: buildPullRequestRefinementPrompt({
+        lane,
+        issue: linkedIssue,
+        pullRequest,
+        worktreePath: worktree.worktreePath,
+        branchName: worktree.branchName,
+        feedback,
+        checks,
+        comments,
+        diff
+      }),
+      sessionId: lane.sessionId
+    },
+    {
+      status: "ok",
+      summary: `Refined PR #${pullRequest.number} for issue #${linkedIssue.number}.`,
+      recommended_next_action: "Validate the updated worktree, push the branch, and merge the pull request.",
+      artifact_refs: [worktree.worktreePath],
+      blocking_questions: [],
+      data: {
+        transcript_reply: `Updated PR #${pullRequest.number} for issue #${linkedIssue.number}.`
+      }
+    }
+  );
+
+  const afterTurnRouter = await savePrSweepState(session, (nextRouter) => {
+    const targetLane = ensureLane(nextRouter, lane.id, lane.name);
+    assignIssueToLane(nextRouter, linkedIssue.number, lane.id, lane.name);
+    return applyLaneTurn(session, nextRouter, targetLane, {
+      sessionId: turn.sessionId,
+      phase: "pr_refinement",
+      result: turn.result,
+      issueNumber: linkedIssue.number,
+      worktreePath: worktree.worktreePath
+    });
+  });
+
+  if (turn.result.status === "needs_input" || turn.result.blocking_questions.length > 0) {
+    const blockerIssue = await createPrSweepBlockerIssue(session, afterTurnRouter, pullRequest, linkedIssue, {
+      feedback:
+        turn.result.blocking_questions[0] ??
+        turn.result.summary ??
+        "PR refinement uncovered a blocker that needs a dedicated follow-up issue."
+    });
+    await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+        blockerIssueNumber: blockerIssue.number,
+        waitingOnIssueNumber: blockerIssue.number,
+        summary: `Opened blocker issue #${blockerIssue.number} while refining PR #${pullRequest.number}.`
+      })
+    }));
+    await closePullRequest(session.project.repoPath, pullRequest.number, {
+      comment: `Closing this PR for now because the automated PR sweep opened blocker issue #${blockerIssue.number}: ${blockerIssue.url}`
+    });
+    return "blocker_issue";
+  }
+
+  try {
+    await resetWorktreeValidationState(worktree.worktreePath);
+    await maybeRunPackageScript(session.project, worktree.worktreePath, "typecheck");
+    await maybeRunPackageScript(session.project, worktree.worktreePath, "build");
+    await maybeRunPackageScript(session.project, worktree.worktreePath, "test");
+  } catch (error) {
+    const blockerIssue = await createPrSweepBlockerIssue(session, afterTurnRouter, pullRequest, linkedIssue, {
+      feedback: error instanceof Error ? error.message : String(error)
+    });
+    await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+        blockerIssueNumber: blockerIssue.number,
+        waitingOnIssueNumber: blockerIssue.number,
+        summary: `Opened blocker issue #${blockerIssue.number} after validation failed for PR #${pullRequest.number}.`
+      })
+    }));
+    await closePullRequest(session.project.repoPath, pullRequest.number, {
+      comment: `Closing this PR for now because validation failed and blocker issue #${blockerIssue.number} was opened: ${blockerIssue.url}`
+    });
+    return "blocker_issue";
+  }
+
+  const gitStatus = await runCommandOrThrow("git", ["status", "--short"], {
+    cwd: worktree.worktreePath
+  });
+  if (!gitStatus.trim()) {
+    const blockerIssue = await createPrSweepBlockerIssue(session, afterTurnRouter, pullRequest, linkedIssue, {
+      feedback: "PR refinement completed without producing any file changes."
+    });
+    await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+        blockerIssueNumber: blockerIssue.number,
+        waitingOnIssueNumber: blockerIssue.number,
+        summary: `Opened blocker issue #${blockerIssue.number} because PR #${pullRequest.number} refinement produced no changes.`
+      })
+    }));
+    await closePullRequest(session.project.repoPath, pullRequest.number, {
+      comment: `Closing this PR for now because refinement produced no changes and blocker issue #${blockerIssue.number} was opened: ${blockerIssue.url}`
+    });
+    return "blocker_issue";
+  }
+
+  await runCommandOrThrow("git", ["add", "-A"], { cwd: worktree.worktreePath });
+  await runCommandOrThrow(
+    "git",
+    ["commit", "-m", `Refine #${linkedIssue.number}: ${summarizeText(linkedIssue.title, 60)}`],
+    { cwd: worktree.worktreePath }
+  );
+  await runCommandOrThrow("git", ["push", "-u", "origin", worktree.branchName], {
+    cwd: worktree.worktreePath
+  });
+  await mergePullRequest(session.project.repoPath, pullRequest.number);
+  return "merged";
+}
+
+async function maybeHandlePrSweep(session: ProjectSession): Promise<boolean> {
+  let router = await loadRouterState(session.paths, session.project.slug);
+  const cache = await loadGitHubCacheState(session.paths, session.project.slug);
+  const openPullRequests = openPullRequestsFromCache(session, cache);
+
+  if (router.prSweep.status === "idle" && !router.prSweep.nextRunAt) {
+    router = await scheduleNextPrSweep(session, router, cache);
+  }
+
+  if (!isPrSweepDue(router.prSweep)) {
+    return false;
+  }
+
+  if (router.openQuestion) {
+    await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: {
+        ...nextRouter.prSweep,
+        pausedIssueWork: true,
+        lastSummary: "PR sweep is waiting for the current Chief of Staff question to be resolved."
+      }
+    }));
+    return true;
+  }
+
+  const hasPendingLaneWork = router.pendingHandoffs.some(
+    (handoff) => handoff.status === "pending" || handoff.status === "in_progress"
+  );
+  if (activeLaneDispatches.size > 0 || hasPendingLaneWork) {
+    await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: {
+        ...nextRouter.prSweep,
+        status: "scheduled",
+        pausedIssueWork: true,
+        lastSummary: "PR sweep is due and is waiting for current lane work to settle before it pauses normal issue routing."
+      }
+    }));
+    return true;
+  }
+
+  router = await savePrSweepState(session, (nextRouter) => ({
+    ...nextRouter,
+    prSweep: startPrSweepState(
+      nextRouter.prSweep,
+      openPullRequests.map((pullRequest) => pullRequest.number),
+      {
+        summary:
+          openPullRequests.length > 0
+            ? `Chief of Staff PR sweep is running across ${openPullRequests.length} open pull request${
+                openPullRequests.length === 1 ? "" : "s"
+              }.`
+            : "Chief of Staff PR sweep is running, but no open pull requests were found."
+      }
+    )
+  }));
+
+  const stats = {
+    reviewed: 0,
+    merged: 0,
+    fixedAndMerged: 0,
+    closed: 0,
+    blockerIssues: 0,
+    escalations: 0
+  };
+
+  for (const pullRequest of openPullRequests) {
+    router = await savePrSweepState(session, (nextRouter) => ({
+      ...nextRouter,
+      prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+        currentPullRequestNumber: pullRequest.number,
+        removePullRequestNumber: pullRequest.number,
+        summary: `Chief of Staff is reviewing PR #${pullRequest.number}.`
+      })
+    }));
+
+    const review = await reviewPullRequestInSweep(session, router, cache, pullRequest);
+    router = review.router;
+    stats.reviewed += 1;
+
+    if (review.decision === "merge") {
+      await mergePullRequest(session.project.repoPath, pullRequest.number);
+      stats.merged += 1;
+      await syncProjectInternal(session);
+      continue;
+    }
+
+    if (review.decision === "close") {
+      await closePullRequest(session.project.repoPath, pullRequest.number, {
+        comment: review.feedback ?? `Closing PR #${pullRequest.number} after the Chief of Staff PR sweep review.`
+      });
+      stats.closed += 1;
+      await syncProjectInternal(session);
+      continue;
+    }
+
+    if (review.decision === "blocker_issue") {
+      const blockerIssue = await createPrSweepBlockerIssue(session, router, pullRequest, review.linkedIssue, {
+        feedback:
+          review.feedback ??
+          `PR #${pullRequest.number} needs broader follow-up work before it can merge.`,
+        task: review.issueTasks[0] ?? null
+      });
+      router = await savePrSweepState(session, (nextRouter) => ({
+        ...nextRouter,
+        prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+          blockerIssueNumber: blockerIssue.number,
+          waitingOnIssueNumber: blockerIssue.number,
+          summary: `Opened blocker issue #${blockerIssue.number} while reviewing PR #${pullRequest.number}.`
+        })
+      }));
+      await closePullRequest(session.project.repoPath, pullRequest.number, {
+        comment: [
+          review.feedback ?? "Closing this PR for now because the PR sweep identified broader follow-up work.",
+          `Opened blocker issue #${blockerIssue.number}: ${blockerIssue.url}`
+        ].join("\n\n")
+      });
+      stats.blockerIssues += 1;
+      stats.closed += 1;
+      await syncProjectInternal(session);
+      continue;
+    }
+
+    if (review.decision === "changes") {
+      if (!review.linkedIssue) {
+        const blockerIssue = await createPrSweepBlockerIssue(session, router, pullRequest, null, {
+          feedback:
+            review.feedback ??
+            `PR #${pullRequest.number} needs refinement before merge, but no linked issue was found for safe ownership.`
+        });
+        router = await savePrSweepState(session, (nextRouter) => ({
+          ...nextRouter,
+          prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+            blockerIssueNumber: blockerIssue.number,
+            waitingOnIssueNumber: blockerIssue.number,
+            summary: `Opened blocker issue #${blockerIssue.number} because PR #${pullRequest.number} had no linked issue for safe refinement.`
+          })
+        }));
+        await closePullRequest(session.project.repoPath, pullRequest.number, {
+          comment: `Closing this PR for now because blocker issue #${blockerIssue.number} was opened to capture the required follow-up: ${blockerIssue.url}`
+        });
+        stats.blockerIssues += 1;
+        stats.closed += 1;
+        await syncProjectInternal(session);
+        continue;
+      }
+
+      const refinementOutcome = await refinePullRequestInSweep(
+        session,
+        router,
+        review.linkedIssue,
+        pullRequest,
+        review.feedback ?? "Refine this pull request branch so it is safe to merge."
+      );
+      if (refinementOutcome === "merged") {
+        stats.merged += 1;
+        stats.fixedAndMerged += 1;
+      } else {
+        const refreshedRouter = await loadRouterState(session.paths, session.project.slug);
+        const latestBlockerNumber = refreshedRouter.prSweep.blockerIssueNumbers.at(-1) ?? null;
+        router = await savePrSweepState(session, (nextRouter) => ({
+          ...nextRouter,
+          prSweep: updateRunningPrSweepState(nextRouter.prSweep, {
+            waitingOnIssueNumber: latestBlockerNumber,
+            summary: latestBlockerNumber
+              ? `Opened blocker issue #${latestBlockerNumber} while refining PR #${pullRequest.number}.`
+              : `PR #${pullRequest.number} could not be merged during automated refinement and was closed for follow-up.`
+          })
+        }));
+        stats.blockerIssues += 1;
+        stats.closed += 1;
+      }
+      await syncProjectInternal(session);
+      continue;
+    }
+
+    const questionText =
+      review.feedback ??
+      `PR #${pullRequest.number} needs a product or taste decision before it can merge safely.`;
+    const timestamp = nowIso();
+    const questionRouter = await loadRouterState(session.paths, session.project.slug);
+    await saveRouterState(session.paths, {
+      ...questionRouter,
+      openQuestion: {
+        id: `question_${Date.now()}`,
+        title: buildHumanQuestionTitle(questionText, {
+          prNumber: pullRequest.number
+        }),
+        summary: review.transcriptReply ?? questionText,
+        question: questionText,
+        whyItMatters:
+          parseDataString(questionRouter.recentRuns.at(-1)?.outputJson?.why_it_matters) ??
+          `The PR sweep reached PR #${pullRequest.number} and could not finish without a human product or taste decision.`,
+        recommendation:
+          parseDataString(questionRouter.recentRuns.at(-1)?.outputJson?.recommendation) ??
+          "Reply with the decision you want the Chief of Staff to apply, then the PR sweep will resume.",
+        issueNumber: review.linkedIssue?.number ?? null,
+        prNumber: pullRequest.number,
+        runId: questionRouter.recentRuns.at(-1)?.id ?? null,
+        requestedBy: "chief_of_staff",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      },
+      orchestrator: {
+        ...questionRouter.orchestrator,
+        lastSummary: `PR sweep is waiting on a human decision for PR #${pullRequest.number}.`
+      },
+      prSweep: {
+        ...questionRouter.prSweep,
+        status: "running",
+        pausedIssueWork: true,
+        currentPullRequestNumber: pullRequest.number,
+        waitingOnIssueNumber: review.linkedIssue?.number ?? null,
+        lastSummary: `PR sweep is waiting on a human decision for PR #${pullRequest.number}.`,
+        updatedAt: timestamp
+      }
+    });
+    await appendConversationMessage(session, {
+      role: "chief_of_staff",
+      kind: "cos_question",
+      content: formatHumanQuestionContent(
+        questionText,
+        `The automated PR sweep could not safely finish PR #${pullRequest.number} without a human decision.`,
+        "Reply with the decision you want applied, then the PR sweep will continue."
+      ),
+      summary: summarizeText(questionText),
+      linkedIssueNumber: review.linkedIssue?.number ?? null,
+      linkedPrNumber: pullRequest.number,
+      linkedPullRequestNumber: pullRequest.number,
+      isOpenQuestion: true
+    });
+    stats.escalations += 1;
+    return true;
+  }
+
+  const refreshedCache = await loadGitHubCacheState(session.paths, session.project.slug);
+  const lastRunAt = nowIso();
+  const summary = summarizePrSweepRun(stats);
+  router = await savePrSweepState(session, (nextRouter) => ({
+    ...nextRouter,
+    prSweep: {
+      ...nextRouter.prSweep,
+      status: "idle",
+      nextRunAt: null,
+      currentPullRequestNumber: null,
+      completedAt: lastRunAt,
+      lastSummary: summary,
+      pausedIssueWork: false
+    }
+  }));
+  router = await scheduleNextPrSweep(session, router, refreshedCache, {
+    completedAt: lastRunAt,
+    lastSummary: summary
+  });
+  await appendConversationMessage(session, {
+    role: "chief_of_staff",
+    kind: "status_update",
+    content: `${summary} ${router.prSweep.lastSummary ?? ""}`.trim(),
+    summary: summary,
+    linkedIssueNumber: null,
+    linkedPrNumber: null,
+    linkedPullRequestNumber: null,
+    isOpenQuestion: false
+  });
+  return true;
+}
+
 async function syncProjectInternal(session: ProjectSession): Promise<DirectorOperationResponse> {
   const metadataChanges = await refreshProjectMetadata(session);
   const [issues, pullRequests, comments] = await Promise.all([
@@ -2275,13 +3383,11 @@ async function chooseNextIssue(session: ProjectSession): Promise<void> {
     .filter((issue) => issue.workflowState === "ready" || issue.workflowState === "queued")
     .filter((issue) => !hasPendingLaneWork(router, issue.number));
   const readyIssues = candidateIssues.filter((issue) => issue.workflowState === "ready");
-  const issues = (readyIssues.length > 0 ? readyIssues : candidateIssues)
-    .filter((issue) => issue.workflowState === "ready" || issue.workflowState === "queued")
-    .sort((left, right) => {
-      const leftPriority = left.workflowState === "ready" ? 0 : 1;
-      const rightPriority = right.workflowState === "ready" ? 0 : 1;
-      return leftPriority - rightPriority || left.number - right.number;
-    });
+  const issues = sortQueueableIssues(
+    (readyIssues.length > 0 ? readyIssues : candidateIssues).filter(
+      (issue) => issue.workflowState === "ready" || issue.workflowState === "queued"
+    )
+  );
 
   if (!issues.length) {
     await saveRouterState(session.paths, {
@@ -3484,6 +4590,9 @@ async function runOrchestratorLoop(): Promise<void> {
 
       shouldReschedule = true;
       await syncProjectInternal(session);
+      if (await maybeHandlePrSweep(session)) {
+        return;
+      }
       await dispatchPendingLaneHandoffs(session);
       await dispatchChiefOfStaffHandoff(session);
       await dispatchPendingLaneHandoffs(session);
@@ -3748,6 +4857,7 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
       project: session.project,
       orchestrator: synthesizeOrchestratorStatus(session.project, router, owner),
       lastSuccessfulSyncAt: resolveLastSuccessfulSyncAt(router.lastSyncAt, cache.syncedAt),
+      prSweep: synthesizePrSweepRecord(router),
       lanes: router.lanes.map((lane) => synthesizeLaneRecord(lane, openPullRequests)),
       issues: issues.map((issue) => synthesizeIssueOwnership(issue, router, pullRequests)),
       openQuestion: router.openQuestion ? toHumanQuestionRecord(router.openQuestion) : null,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export const PR_CYCLE_STATUSES = [
   "merged",
   "blocked"
 ] as const;
+export const PR_SWEEP_STATUSES = ["idle", "scheduled", "running"] as const;
 export const SETUP_CHECK_KINDS = ["repository", "github", "codex", "workspace"] as const;
 export const SETUP_CHECK_STATUSES = [
   "ready",
@@ -86,6 +87,7 @@ export type NoteStatus = (typeof NOTE_STATUSES)[number];
 export type ConversationMessageRole = (typeof CONVERSATION_MESSAGE_ROLES)[number];
 export type ConversationMessageKind = (typeof CONVERSATION_MESSAGE_KINDS)[number];
 export type PrCycleStatus = (typeof PR_CYCLE_STATUSES)[number];
+export type PrSweepStatus = (typeof PR_SWEEP_STATUSES)[number];
 export type SetupCheckKind = (typeof SETUP_CHECK_KINDS)[number];
 export type SetupCheckStatus = (typeof SETUP_CHECK_STATUSES)[number];
 export type SetupProblemCode = (typeof SETUP_PROBLEM_CODES)[number];
@@ -297,6 +299,20 @@ export interface ActivityRecord {
   createdAt: string;
 }
 
+export interface PrSweepRecord {
+  status: PrSweepStatus;
+  nextRunAt: string | null;
+  currentPullRequestNumber: number | null;
+  pendingPullRequestNumbers: number[];
+  blockerIssueNumbers: number[];
+  waitingOnIssueNumber: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  lastSummary: string | null;
+  pausedIssueWork: boolean;
+  updatedAt: string | null;
+}
+
 export interface AgentResultEnvelope {
   status: "ok" | "needs_input" | "failed";
   summary: string;
@@ -347,6 +363,7 @@ export interface DirectorStatusResponse {
   project: ProjectRecord | null;
   orchestrator: OrchestratorStatusRecord | null;
   lastSuccessfulSyncAt: string | null;
+  prSweep: PrSweepRecord | null;
   lanes: LaneRecord[];
   issues: IssueOwnershipRecord[];
   openQuestion: HumanQuestionRecord | null;


### PR DESCRIPTION
Closes #98

## Summary
- add Chief of Staff-managed PR sweep state, scheduling, review, refinement, blocker issue creation, and loop pause/resume behavior
- surface PR sweep status and recent automation activity in the Control Room and CLI
- extend shared contracts and tests for PR sweep state, blocker prioritization, and router reset behavior

## Verification
- npm run typecheck
- npm test
- npm run build