### PR TITLE
Add project settings and stale-branch recovery to the control room

### DIFF
--- a/apps/desktop/src/preload.cts
+++ b/apps/desktop/src/preload.cts
@@ -7,7 +7,8 @@ import type {
   DirectorStatusResponse,
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
-  SetupStatusResponse
+  SetupStatusResponse,
+  UpdateProjectSettingsInput
 } from "@director-os/shared";
 
 import { IPC_CHANNELS } from "./protocol.js";
@@ -34,6 +35,8 @@ const api: DirectorDesktopBridge = {
     start: () => invoke(IPC_CHANNELS.director.start),
     pause: (reason?: string) => invoke(IPC_CHANNELS.director.pause, reason),
     sync: () => invoke(IPC_CHANNELS.director.sync),
+    updateProjectSettings: (input: UpdateProjectSettingsInput) =>
+      invoke(IPC_CHANNELS.director.updateProjectSettings, input),
     resetRouterRuntime: () => invoke(IPC_CHANNELS.director.resetRouterRuntime)
   }
 };

--- a/apps/desktop/src/protocol.ts
+++ b/apps/desktop/src/protocol.ts
@@ -14,6 +14,7 @@ export const IPC_CHANNELS = {
     start: "director:start",
     pause: "director:pause",
     sync: "director:sync",
+    updateProjectSettings: "director:update-project-settings",
     resetRouterRuntime: "director:reset-router-runtime"
   }
 } as const;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,7 +8,8 @@ import type {
   RunRecord,
   SetupCheck,
   SetupRepositoryDraft,
-  SetupStatusResponse
+  SetupStatusResponse,
+  UpdateProjectSettingsInput
 } from "./api";
 import {
   completeSetup,
@@ -21,7 +22,8 @@ import {
   runWorkspaceTest,
   sendMessage,
   startDirector,
-  syncNow
+  syncNow,
+  updateProjectSettings as saveProjectSettings
 } from "./api";
 import { deriveSetupStateBadge, hasCompletedSetup } from "./setup-state";
 
@@ -48,6 +50,8 @@ export function App() {
   const [setupStatus, setSetupStatus] = useState<SetupStatusResponse | null>(null);
   const [status, setStatus] = useState<DirectorStatusResponse | null>(null);
   const [conversation, setConversation] = useState<ConversationResponse | null>(null);
+  const [projectSettingsDraft, setProjectSettingsDraft] = useState<UpdateProjectSettingsInput | null>(null);
+  const [editingProjectSettings, setEditingProjectSettings] = useState(false);
   const [repositoryPath, setRepositoryPath] = useState("");
   const [projectName, setProjectName] = useState("");
   const [worktreeRoot, setWorktreeRoot] = useState("");
@@ -136,6 +140,9 @@ export function App() {
 
     if (statusResult.status === "fulfilled") {
       setStatus(statusResult.value);
+      if (!editingProjectSettings || !projectSettingsDraft) {
+        hydrateProjectSettingsDraft(statusResult.value);
+      }
     } else {
       setError(statusResult.reason instanceof Error ? statusResult.reason.message : String(statusResult.reason));
     }
@@ -162,6 +169,21 @@ export function App() {
     setProjectName(draft.projectName ?? "");
     setWorktreeRoot(draft.worktreeRoot ?? "");
     setModelName(draft.model ?? "");
+  }
+
+  function hydrateProjectSettingsDraft(nextStatus: DirectorStatusResponse | null) {
+    if (!nextStatus?.project) {
+      return;
+    }
+
+    setProjectSettingsDraft({
+      repoPath: nextStatus.project.repoPath,
+      repoSlug: nextStatus.project.repoSlug,
+      defaultBranch: nextStatus.project.defaultBranch,
+      defaultBranchStrategy: nextStatus.projectConfigStatus?.defaultBranchStrategy ?? "repo_default",
+      worktreeRoot: nextStatus.project.worktreeRoot,
+      model: nextStatus.project.model
+    });
   }
 
   async function runSetupAction(actionKey: string, runner: () => Promise<SetupStatusResponse>) {
@@ -290,6 +312,45 @@ export function App() {
     }
 
     await runDashboardAction("reset-router-runtime", async () => resetRouterRuntime());
+  }
+
+  async function handleSaveProjectSettings() {
+    if (!projectSettingsDraft) {
+      setError("Project settings are not ready to save yet.");
+      return;
+    }
+
+    await runDashboardAction("save-project-settings", async () => {
+      const nextStatus = await saveProjectSettings(projectSettingsDraft);
+      setStatus(nextStatus);
+      hydrateProjectSettingsDraft(nextStatus);
+      setEditingProjectSettings(false);
+      await refreshWorkspace();
+    });
+  }
+
+  async function handleHealBaseBranch() {
+    if (!status?.project || !status.projectConfigStatus?.repoDefaultBranch) {
+      setError("The local repo default branch is not available to recover from.");
+      return;
+    }
+
+    const nextDraft: UpdateProjectSettingsInput = {
+      repoPath: status.project.repoPath,
+      repoSlug: status.project.repoSlug,
+      defaultBranch: status.projectConfigStatus.repoDefaultBranch,
+      defaultBranchStrategy: "repo_default",
+      worktreeRoot: status.project.worktreeRoot,
+      model: status.project.model
+    };
+
+    await runDashboardAction("heal-base-branch", async () => {
+      const nextStatus = await saveProjectSettings(nextDraft);
+      setStatus(nextStatus);
+      hydrateProjectSettingsDraft(nextStatus);
+      setEditingProjectSettings(false);
+      await refreshWorkspace();
+    });
   }
 
   if (shellMode === "booting") {
@@ -496,6 +557,236 @@ export function App() {
             <div className="list-note">
               The Chief of Staff loop stays local and routes work through persistent lane sessions.
             </div>
+          </section>
+
+          <section className="panel sidebar-card">
+            <div className="panel-header">
+              <div>
+                <div className="section-title">Project settings</div>
+                <div className="section-meta">
+                  Repo, base branch, worktree root, and model settings for the active project.
+                </div>
+              </div>
+              <span
+                className={`check-pill ${
+                  status?.projectConfigStatus?.branchStatus === "stale"
+                    ? "check-pill-needs-action"
+                    : "check-pill-ready"
+                }`}
+              >
+                {status?.projectConfigStatus
+                  ? status.projectConfigStatus.branchStatus === "stale"
+                    ? "Needs recovery"
+                    : status.projectConfigStatus.defaultBranchStrategy === "custom"
+                      ? "Custom base"
+                      : "Repo default"
+                  : "Unavailable"}
+              </span>
+            </div>
+            {editingProjectSettings && projectSettingsDraft ? (
+              <div className="setup-form">
+                <label className="field-group">
+                  <span className="field-label">Repo path</span>
+                  <input
+                    className="text-field"
+                    value={projectSettingsDraft.repoPath}
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              repoPath: event.target.value
+                            }
+                          : current
+                      )
+                    }
+                  />
+                </label>
+                <label className="field-group">
+                  <span className="field-label">Repo slug</span>
+                  <input
+                    className="text-field"
+                    value={projectSettingsDraft.repoSlug}
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              repoSlug: event.target.value
+                            }
+                          : current
+                      )
+                    }
+                  />
+                </label>
+                <label className="field-group">
+                  <span className="field-label">Base branch mode</span>
+                  <select
+                    className="text-field"
+                    value={projectSettingsDraft.defaultBranchStrategy}
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              defaultBranchStrategy:
+                                event.target.value === "custom" ? "custom" : "repo_default",
+                              defaultBranch:
+                                event.target.value === "custom"
+                                  ? current.defaultBranch
+                                  : status?.projectConfigStatus?.repoDefaultBranch ?? current.defaultBranch
+                            }
+                          : current
+                      )
+                    }
+                  >
+                    <option value="repo_default">Repo default</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                </label>
+                <label className="field-group">
+                  <span className="field-label">PR target branch</span>
+                  <input
+                    className="text-field"
+                    disabled={projectSettingsDraft.defaultBranchStrategy === "repo_default"}
+                    value={
+                      projectSettingsDraft.defaultBranchStrategy === "repo_default"
+                        ? status?.projectConfigStatus?.repoDefaultBranch ?? projectSettingsDraft.defaultBranch
+                        : projectSettingsDraft.defaultBranch
+                    }
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              defaultBranch: event.target.value
+                            }
+                          : current
+                      )
+                    }
+                  />
+                </label>
+                <label className="field-group">
+                  <span className="field-label">Worktree root</span>
+                  <input
+                    className="text-field"
+                    value={projectSettingsDraft.worktreeRoot}
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              worktreeRoot: event.target.value
+                            }
+                          : current
+                      )
+                    }
+                  />
+                </label>
+                <label className="field-group">
+                  <span className="field-label">Model</span>
+                  <input
+                    className="text-field"
+                    value={projectSettingsDraft.model}
+                    onChange={(event) =>
+                      setProjectSettingsDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              model: event.target.value
+                            }
+                          : current
+                      )
+                    }
+                  />
+                </label>
+                <div className="inline-actions">
+                  <button
+                    className="action-button action-button-primary"
+                    disabled={busyAction === "save-project-settings"}
+                    onClick={() => void handleSaveProjectSettings()}
+                  >
+                    {busyAction === "save-project-settings" ? "Saving..." : "Save settings"}
+                  </button>
+                  <button
+                    className="action-button action-button-secondary"
+                    onClick={() => {
+                      hydrateProjectSettingsDraft(status);
+                      setEditingProjectSettings(false);
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="meta-pairs">
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">Repo path</span>
+                    <span className="meta-pair-value">{status?.project?.repoPath ?? "Unavailable"}</span>
+                  </div>
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">Worktree root</span>
+                    <span className="meta-pair-value">{status?.project?.worktreeRoot ?? "Unavailable"}</span>
+                  </div>
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">PR target branch</span>
+                    <span className="meta-pair-value">{status?.project?.defaultBranch ?? "Unavailable"}</span>
+                  </div>
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">Branch mode</span>
+                    <span className="meta-pair-value">
+                      {status?.projectConfigStatus?.defaultBranchStrategy === "custom"
+                        ? "Custom"
+                        : "Repo default"}
+                    </span>
+                  </div>
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">Repo default branch</span>
+                    <span className="meta-pair-value">
+                      {status?.projectConfigStatus?.repoDefaultBranch ?? "Unavailable"}
+                    </span>
+                  </div>
+                  <div className="meta-pair">
+                    <span className="meta-pair-label">Current local branch</span>
+                    <span className="meta-pair-value">
+                      {status?.projectConfigStatus?.currentBranch ?? "Unavailable"}
+                    </span>
+                  </div>
+                </div>
+                <div className="compact-card">
+                  <div className="compact-card-meta">
+                    <span>{status?.project?.repoSlug ?? "No repo slug"}</span>
+                    <span>{status?.project?.model ?? "No model"}</span>
+                  </div>
+                  <div className="list-note">
+                    {status?.projectConfigStatus?.branchStatusSummary ??
+                      "Project settings are not available yet."}
+                  </div>
+                </div>
+                <div className="inline-actions">
+                  <button
+                    className="action-button action-button-secondary"
+                    onClick={() => {
+                      hydrateProjectSettingsDraft(status);
+                      setEditingProjectSettings(true);
+                    }}
+                  >
+                    Edit settings
+                  </button>
+                  {status?.projectConfigStatus?.canHealToRepoDefault ? (
+                    <button
+                      className="action-button action-button-primary"
+                      disabled={busyAction === "heal-base-branch"}
+                      onClick={() => void handleHealBaseBranch()}
+                    >
+                      {busyAction === "heal-base-branch" ? "Recovering..." : "Use repo default"}
+                    </button>
+                  ) : null}
+                </div>
+              </>
+            )}
           </section>
 
           <section className="panel sidebar-card recovery-card">

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -11,7 +11,8 @@ import type {
   SetupCheck,
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
-  SetupStatusResponse
+  SetupStatusResponse,
+  UpdateProjectSettingsInput
 } from "@director-os/shared";
 
 export type {
@@ -24,7 +25,8 @@ export type {
   SetupCheck,
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
-  SetupStatusResponse
+  SetupStatusResponse,
+  UpdateProjectSettingsInput
 } from "@director-os/shared";
 
 declare global {
@@ -104,6 +106,11 @@ function createHttpDirectorClient(): WebDirectorClient {
       requestJson<DirectorOperationResponse>("/api/sync", {
         method: "POST"
       }),
+    updateProjectSettings: (input: UpdateProjectSettingsInput) =>
+      requestJson<DirectorStatusResponse>("/api/project/settings", {
+        method: "POST",
+        body: JSON.stringify(input)
+      }),
     resetRouterRuntime: () =>
       requestJson<DirectorOperationResponse>("/api/reset-router-runtime", {
         method: "POST"
@@ -124,6 +131,8 @@ function createIpcDirectorClient(bridge: DirectorDesktopBridge): WebDirectorClie
     start: () => bridge.director.start(),
     pause: (reason?: string) => bridge.director.pause(reason),
     sync: () => bridge.director.sync(),
+    updateProjectSettings: (input: UpdateProjectSettingsInput) =>
+      bridge.director.updateProjectSettings(input),
     resetRouterRuntime: () => bridge.director.resetRouterRuntime()
   };
 }
@@ -186,6 +195,12 @@ export async function pauseDirector(reason?: string): Promise<DirectorOperationR
 
 export async function syncNow(): Promise<DirectorOperationResponse> {
   return getDirectorClient().sync();
+}
+
+export async function updateProjectSettings(
+  input: UpdateProjectSettingsInput
+): Promise<DirectorStatusResponse> {
+  return getDirectorClient().updateProjectSettings(input);
 }
 
 export async function resetRouterRuntime(): Promise<DirectorOperationResponse> {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -16,7 +16,8 @@ import {
   runWorkspaceSetupTest,
   startOrchestrator,
   sendConversationMessage,
-  syncProject
+  syncProject,
+  updateProjectSettings
 } from "./services.js";
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
@@ -92,6 +93,16 @@ export async function createDirectorServer() {
     pauseOrchestrator(request.body?.reason)
   );
   app.post("/api/sync", async () => syncProject());
+  app.post<{
+    Body: {
+      repoPath: string;
+      repoSlug: string;
+      defaultBranch: string;
+      defaultBranchStrategy: "repo_default" | "custom";
+      worktreeRoot: string;
+      model: string;
+    };
+  }>("/api/project/settings", async (request) => updateProjectSettings(request.body));
   app.post("/api/reset-router-runtime", async () => resetRouterRuntime());
 
   app.setNotFoundHandler(async (request, reply) => {

--- a/packages/core/src/services.test.ts
+++ b/packages/core/src/services.test.ts
@@ -27,6 +27,7 @@ import {
   schedulePrSweepState,
   sortQueueableIssues,
   startPrSweepState,
+  synthesizeProjectConfigStatus,
   updateRunningPrSweepState
 } from "./services.js";
 
@@ -224,6 +225,83 @@ describe("reconcileProjectConfigWithRepository", () => {
     expect(reconciled.changes).toContain(
       "Updated repo slug from old/director-os to njuneja27/director-os."
     );
+  });
+});
+
+describe("synthesizeProjectConfigStatus", () => {
+  it("reports a healthy repo-default target when the stored and detected defaults match", () => {
+    const status = synthesizeProjectConfigStatus(makeProjectConfig(), {
+      repoDefaultBranch: "main",
+      currentBranch: "main"
+    });
+
+    expect(status).toEqual({
+      defaultBranchStrategy: "repo_default",
+      repoDefaultBranch: "main",
+      currentBranch: "main",
+      branchStatus: "healthy",
+      branchStatusSummary: "Targeting repo default branch main.",
+      canHealToRepoDefault: false
+    });
+  });
+
+  it("flags stale repo-default targets and exposes a recovery action", () => {
+    const status = synthesizeProjectConfigStatus(
+      makeProjectConfig({
+        defaultBranch: "codex/issue-53-54-55-routing"
+      }),
+      {
+        repoDefaultBranch: "main",
+        currentBranch: "main"
+      }
+    );
+
+    expect(status.defaultBranchStrategy).toBe("repo_default");
+    expect(status.branchStatus).toBe("stale");
+    expect(status.repoDefaultBranch).toBe("main");
+    expect(status.currentBranch).toBe("main");
+    expect(status.canHealToRepoDefault).toBe(true);
+    expect(status.branchStatusSummary).toContain("stale");
+    expect(status.branchStatusSummary).toContain("main");
+  });
+
+  it("surfaces custom targets without offering repo-default healing", () => {
+    const status = synthesizeProjectConfigStatus(
+      makeProjectConfig({
+        defaultBranch: "release/preview",
+        defaultBranchStrategy: "custom"
+      }),
+      {
+        repoDefaultBranch: "main",
+        currentBranch: "release/preview"
+      }
+    );
+
+    expect(status).toEqual({
+      defaultBranchStrategy: "custom",
+      repoDefaultBranch: "main",
+      currentBranch: "release/preview",
+      branchStatus: "custom",
+      branchStatusSummary: "Targeting custom base branch release/preview instead of repo default main.",
+      canHealToRepoDefault: false
+    });
+  });
+
+  it("falls back to unknown when the local repo default cannot be detected", () => {
+    const status = synthesizeProjectConfigStatus(makeProjectConfig(), {
+      repoDefaultBranch: null,
+      currentBranch: "main"
+    });
+
+    expect(status).toEqual({
+      defaultBranchStrategy: "repo_default",
+      repoDefaultBranch: null,
+      currentBranch: "main",
+      branchStatus: "unknown",
+      branchStatusSummary:
+        "Targeting base branch main, but the local repo default branch could not be detected yet.",
+      canHealToRepoDefault: false
+    });
   });
 });
 

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -18,6 +18,7 @@ import type {
   IssueOwnershipRecord,
   LaneRecord,
   OrchestratorStatusRecord,
+  ProjectConfigStatusRecord,
   ProjectRecord,
   RunRecord,
   SetupCheck,
@@ -25,7 +26,8 @@ import type {
   SetupProblemCode,
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
-  SetupStatusResponse
+  SetupStatusResponse,
+  UpdateProjectSettingsInput
 } from "@director-os/shared";
 
 import {
@@ -670,6 +672,89 @@ async function getCurrentGitBranch(repoPath: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+async function getLocalRepoDefaultBranch(repoPath: string): Promise<string | null> {
+  try {
+    const symbolicRef = await runCommandOrThrow(
+      "git",
+      ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+      {
+        cwd: repoPath
+      }
+    );
+    const trimmed = symbolicRef.trim();
+    const prefix = "refs/remotes/origin/";
+    return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function synthesizeProjectConfigStatus(
+  projectConfig: StoredProjectConfig,
+  resolution: {
+    repoDefaultBranch?: string | null;
+    currentBranch?: string | null;
+  }
+): ProjectConfigStatusRecord {
+  const defaultBranchStrategy =
+    projectConfig.defaultBranchStrategy === "custom" ? "custom" : "repo_default";
+  const repoDefaultBranch = resolution.repoDefaultBranch?.trim() || null;
+  const currentBranch = resolution.currentBranch?.trim() || null;
+  const defaultBranch = projectConfig.defaultBranch.trim() || repoDefaultBranch || "main";
+  const canHealToRepoDefault =
+    defaultBranchStrategy === "repo_default" &&
+    Boolean(repoDefaultBranch) &&
+    defaultBranch !== repoDefaultBranch;
+
+  if (!repoDefaultBranch) {
+    return {
+      defaultBranchStrategy,
+      repoDefaultBranch: null,
+      currentBranch,
+      branchStatus: defaultBranchStrategy === "custom" ? "custom" : "unknown",
+      branchStatusSummary:
+        defaultBranchStrategy === "custom"
+          ? `Targeting custom base branch ${defaultBranch}. The local repo default branch could not be detected.`
+          : `Targeting base branch ${defaultBranch}, but the local repo default branch could not be detected yet.`,
+      canHealToRepoDefault: false
+    };
+  }
+
+  if (defaultBranchStrategy === "custom") {
+    return {
+      defaultBranchStrategy,
+      repoDefaultBranch,
+      currentBranch,
+      branchStatus: "custom",
+      branchStatusSummary:
+        defaultBranch === repoDefaultBranch
+          ? `Targeting ${defaultBranch} with a custom base-branch setting.`
+          : `Targeting custom base branch ${defaultBranch} instead of repo default ${repoDefaultBranch}.`,
+      canHealToRepoDefault: false
+    };
+  }
+
+  if (defaultBranch !== repoDefaultBranch) {
+    return {
+      defaultBranchStrategy,
+      repoDefaultBranch,
+      currentBranch,
+      branchStatus: "stale",
+      branchStatusSummary: `Stored repo-default target ${defaultBranch} is stale; the local repo default branch is ${repoDefaultBranch}.`,
+      canHealToRepoDefault: true
+    };
+  }
+
+  return {
+    defaultBranchStrategy,
+    repoDefaultBranch,
+    currentBranch,
+    branchStatus: "healthy",
+    branchStatusSummary: `Targeting repo default branch ${repoDefaultBranch}.`,
+    canHealToRepoDefault: false
+  };
 }
 
 async function resolveProjectRepositoryMetadata(
@@ -4963,12 +5048,74 @@ export async function syncProject(): Promise<DirectorOperationResponse> {
   return withProject(async (session) => syncProjectInternal(session));
 }
 
+export async function updateProjectSettings(
+  input: UpdateProjectSettingsInput
+): Promise<DirectorStatusResponse> {
+  return withProject(async (session) => {
+    const repoPathInput = input.repoPath.trim();
+    const repoSlug = input.repoSlug.trim();
+    const worktreeRootInput = input.worktreeRoot.trim();
+    const defaultBranchInput = input.defaultBranch.trim();
+    const model = input.model.trim();
+    const defaultBranchStrategy =
+      input.defaultBranchStrategy === "custom" ? "custom" : "repo_default";
+
+    if (!repoPathInput) {
+      throw new Error("Repo path is required.");
+    }
+    if (!repoSlug) {
+      throw new Error("Repo slug is required.");
+    }
+    if (!worktreeRootInput) {
+      throw new Error("Worktree root is required.");
+    }
+    if (!model) {
+      throw new Error("Model is required.");
+    }
+    if (defaultBranchStrategy === "custom" && !defaultBranchInput) {
+      throw new Error("A custom base branch is required when branch mode is custom.");
+    }
+
+    const nextProjectConfigBase: StoredProjectConfig = {
+      ...session.projectConfig,
+      repoPath: resolveRepoPath(repoPathInput),
+      repoSlug,
+      defaultBranch: defaultBranchInput || session.projectConfig.defaultBranch,
+      defaultBranchStrategy,
+      worktreeRoot: path.resolve(worktreeRootInput),
+      model,
+      updatedAt: nowIso()
+    };
+
+    const resolution = await resolveProjectRepositoryMetadata(nextProjectConfigBase);
+    const repoDefaultBranch = resolution.repoDefaultBranch?.trim() || null;
+    const nextProjectConfig: StoredProjectConfig = {
+      ...nextProjectConfigBase,
+      repoSlug: resolution.repoSlug?.trim() || nextProjectConfigBase.repoSlug,
+      defaultBranch:
+        defaultBranchStrategy === "repo_default"
+          ? repoDefaultBranch || nextProjectConfigBase.defaultBranch
+          : nextProjectConfigBase.defaultBranch,
+      updatedAt: nowIso()
+    };
+
+    const nextConfig = upsertProjectConfig(session.config, nextProjectConfig);
+    nextConfig.activeProjectSlug = session.config.activeProjectSlug;
+    await saveConfig(nextConfig, session.paths);
+    await initializeProjectRuntime(session.paths, nextProjectConfig);
+
+    return getDirectorStatus();
+  });
+}
+
 export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
   return withProject(async (session) => {
-    const [router, cache, owner] = await Promise.all([
+    const [router, cache, owner, currentBranch, repoDefaultBranch] = await Promise.all([
       loadRouterState(session.paths, session.project.slug),
       loadGitHubCacheState(session.paths, session.project.slug),
-      readOrchestratorLock(session.paths)
+      readOrchestratorLock(session.paths),
+      getCurrentGitBranch(session.project.repoPath),
+      getLocalRepoDefaultBranch(session.project.repoPath)
     ]);
 
     const issues = cache.issues.map((issue) => mapRemoteIssue(session.project, issue));
@@ -4981,6 +5128,10 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
 
     return {
       project: session.project,
+      projectConfigStatus: synthesizeProjectConfigStatus(session.projectConfig, {
+        currentBranch,
+        repoDefaultBranch
+      }),
       orchestrator: synthesizeOrchestratorStatus(session.project, router, owner),
       lastSuccessfulSyncAt: resolveLastSuccessfulSyncAt(router.lastSyncAt, cache.syncedAt),
       prSweep: synthesizePrSweepRecord(router),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -313,6 +313,15 @@ export interface PrSweepRecord {
   updatedAt: string | null;
 }
 
+export interface ProjectConfigStatusRecord {
+  defaultBranchStrategy: "repo_default" | "custom";
+  repoDefaultBranch: string | null;
+  currentBranch: string | null;
+  branchStatus: "healthy" | "stale" | "custom" | "unknown";
+  branchStatusSummary: string;
+  canHealToRepoDefault: boolean;
+}
+
 export interface AgentResultEnvelope {
   status: "ok" | "needs_input" | "failed";
   summary: string;
@@ -361,6 +370,7 @@ export interface SetupStatusResponse {
 
 export interface DirectorStatusResponse {
   project: ProjectRecord | null;
+  projectConfigStatus: ProjectConfigStatusRecord | null;
   orchestrator: OrchestratorStatusRecord | null;
   lastSuccessfulSyncAt: string | null;
   prSweep: PrSweepRecord | null;
@@ -385,6 +395,15 @@ export interface DirectorOperationResponse {
   [key: string]: unknown;
 }
 
+export interface UpdateProjectSettingsInput {
+  repoPath: string;
+  repoSlug: string;
+  defaultBranch: string;
+  defaultBranchStrategy: "repo_default" | "custom";
+  worktreeRoot: string;
+  model: string;
+}
+
 export interface DirectorClient {
   getSetupStatus(): Promise<SetupStatusResponse>;
   probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;
@@ -396,6 +415,7 @@ export interface DirectorClient {
   start(): Promise<DirectorOperationResponse>;
   pause(reason?: string): Promise<DirectorOperationResponse>;
   sync(): Promise<DirectorOperationResponse>;
+  updateProjectSettings(input: UpdateProjectSettingsInput): Promise<DirectorStatusResponse>;
   resetRouterRuntime(): Promise<DirectorOperationResponse>;
 }
 
@@ -415,6 +435,7 @@ export interface DirectorDesktopBridge {
     start(): Promise<DirectorOperationResponse>;
     pause(reason?: string): Promise<DirectorOperationResponse>;
     sync(): Promise<DirectorOperationResponse>;
+    updateProjectSettings(input: UpdateProjectSettingsInput): Promise<DirectorStatusResponse>;
     resetRouterRuntime(): Promise<DirectorOperationResponse>;
   };
 }


### PR DESCRIPTION
## Summary
- add a Control Room project-settings panel for repo path, repo slug, base-branch mode, worktree root, and model
- surface stale base-branch drift versus the local repo default and allow one-click recovery back to the repo default
- add shared contracts, server/API plumbing, desktop bridge typing, and regression tests for branch-status synthesis

## Testing
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`

Closes #72
Closes #73