### PR TITLE
Make lane assignment visible in the control room

### DIFF
--- a/apps/desktop/src/preload.cts
+++ b/apps/desktop/src/preload.cts
@@ -8,6 +8,7 @@ import type {
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
   SetupStatusResponse,
+  UpdateIssueLaneAssignmentInput,
   UpdateProjectSettingsInput
 } from "@director-os/shared";
 
@@ -37,6 +38,8 @@ const api: DirectorDesktopBridge = {
     sync: () => invoke(IPC_CHANNELS.director.sync),
     updateProjectSettings: (input: UpdateProjectSettingsInput) =>
       invoke(IPC_CHANNELS.director.updateProjectSettings, input),
+    updateIssueLaneAssignment: (issueNumber: number, input: UpdateIssueLaneAssignmentInput) =>
+      invoke(IPC_CHANNELS.director.updateIssueLaneAssignment, issueNumber, input),
     resetRouterRuntime: () => invoke(IPC_CHANNELS.director.resetRouterRuntime)
   }
 };

--- a/apps/desktop/src/protocol.ts
+++ b/apps/desktop/src/protocol.ts
@@ -15,6 +15,7 @@ export const IPC_CHANNELS = {
     pause: "director:pause",
     sync: "director:sync",
     updateProjectSettings: "director:update-project-settings",
+    updateIssueLaneAssignment: "director:update-issue-lane-assignment",
     resetRouterRuntime: "director:reset-router-runtime"
   }
 } as const;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import {
   sendMessage,
   startDirector,
   syncNow,
+  updateIssueLaneAssignment as saveIssueLaneAssignment,
   updateProjectSettings as saveProjectSettings
 } from "./api";
 import { deriveSetupStateBadge, hasCompletedSetup } from "./setup-state";
@@ -52,6 +53,8 @@ export function App() {
   const [conversation, setConversation] = useState<ConversationResponse | null>(null);
   const [projectSettingsDraft, setProjectSettingsDraft] = useState<UpdateProjectSettingsInput | null>(null);
   const [editingProjectSettings, setEditingProjectSettings] = useState(false);
+  const [editingLaneIssueNumber, setEditingLaneIssueNumber] = useState<number | null>(null);
+  const [laneDraft, setLaneDraft] = useState("");
   const [repositoryPath, setRepositoryPath] = useState("");
   const [projectName, setProjectName] = useState("");
   const [worktreeRoot, setWorktreeRoot] = useState("");
@@ -349,6 +352,24 @@ export function App() {
       setStatus(nextStatus);
       hydrateProjectSettingsDraft(nextStatus);
       setEditingProjectSettings(false);
+      await refreshWorkspace();
+    });
+  }
+
+  async function handleSaveIssueLaneAssignment(issueNumber: number) {
+    const nextLaneName = laneDraft.trim();
+    if (!nextLaneName) {
+      setError("Lane name is required.");
+      return;
+    }
+
+    await runDashboardAction(`save-issue-lane-${issueNumber}`, async () => {
+      const nextStatus = await saveIssueLaneAssignment(issueNumber, {
+        laneName: nextLaneName
+      });
+      setStatus(nextStatus);
+      setEditingLaneIssueNumber(null);
+      setLaneDraft("");
       await refreshWorkspace();
     });
   }
@@ -920,7 +941,7 @@ export function App() {
             <div className="panel-header">
               <div>
                 <div className="section-title">Lanes</div>
-                <div className="section-meta">Persistent Codex sessions owned by the Chief of Staff. Independent lanes can run in parallel when they own different issues.</div>
+                <div className="section-meta">Persistent Codex sessions owned by the Chief of Staff. Parallel lane work only happens when issues are distributed across different lane IDs.</div>
               </div>
             </div>
             <ItemList<DirectorStatusResponse["lanes"][number]>
@@ -932,6 +953,7 @@ export function App() {
                     <div className="list-title">{lane.name}</div>
                     <div className="list-meta">
                       <span>{String(lane.status).replace("_", " ")}</span>
+                      <span>{lane.ownedIssueNumbers.length} issue{lane.ownedIssueNumbers.length === 1 ? "" : "s"}</span>
                       {lane.currentIssueNumber ? <span>Issue #{lane.currentIssueNumber}</span> : null}
                       {lane.activePullRequestNumber ? <span>PR #{lane.activePullRequestNumber}</span> : null}
                     </div>
@@ -945,27 +967,100 @@ export function App() {
           <section className="panel sidebar-card">
             <div className="panel-header">
               <div>
-                <div className="section-title">Owned issues</div>
-                <div className="section-meta">GitHub issues stay durable; the router only shows whether the Chief of Staff or a lane currently owns each slice.</div>
+                <div className="section-title">Issue lanes</div>
+                <div className="section-meta">GitHub labels are the durable lane preference. Change them here to rebalance work across distinct lane IDs without dropping into the terminal.</div>
               </div>
             </div>
             <ItemList<DirectorStatusResponse["issues"][number]>
-              empty="No GitHub issues are currently owned by the Chief of Staff or a lane."
-              items={(status?.issues ?? []).filter((issue) => issue.state.toLowerCase() === "open" && issue.ownerKind)}
+              empty="No open GitHub issues are available for lane routing yet."
+              items={(status?.issues ?? []).filter((issue) => issue.state.toLowerCase() === "open")}
               render={(issue) => (
-                <div className="list-row compact-list-row" key={issue.issueNumber}>
-                  <div>
+                <div className="compact-card" key={issue.issueNumber}>
+                  <div className="compact-card-head">
                     <div className="list-title">#{issue.issueNumber} {issue.title}</div>
-                    <div className="list-meta">
-                      {issue.ownerName ? <span>{issue.ownerName}</span> : null}
-                      <span>{String(issue.status).replace("_", " ")}</span>
-                      {issue.linkedPullRequestNumber ? <span>PR #{issue.linkedPullRequestNumber}</span> : null}
-                    </div>
+                    <span
+                      className={`check-pill ${
+                        issue.preferredLaneSource === "explicit"
+                          ? "check-pill-ready"
+                          : "check-pill-needs-action"
+                      }`}
+                    >
+                      {issue.preferredLaneSource === "explicit" ? "Explicit lane" : "Fallback lane"}
+                    </span>
                   </div>
-                  <div className="list-note">{issue.lastSummary ?? issue.workflowState}</div>
+                  <div className="compact-card-meta">
+                    <span>{issue.ownerName ?? "Unassigned"}</span>
+                    <span>{String(issue.status).replace("_", " ")}</span>
+                    <span>Target {issue.preferredLaneName ?? "Delivery"}</span>
+                    {issue.laneName ? <span>Active {issue.laneName}</span> : null}
+                    {issue.linkedPullRequestNumber ? <span>PR #{issue.linkedPullRequestNumber}</span> : null}
+                  </div>
+                  <div className="list-note">
+                    {issue.preferredLaneSource === "explicit"
+                      ? `GitHub is explicitly routing this issue to ${issue.preferredLaneName}.`
+                      : `This issue will fall back to ${issue.preferredLaneName} until an explicit lane is set.`}{" "}
+                    {issue.sharedLaneIssueCount > 1
+                      ? `${issue.sharedLaneIssueCount} open issues currently target this lane, so they will still serialize there.`
+                      : "This lane currently has room to run independently without sharing a same-lane queue."}
+                  </div>
+                  {editingLaneIssueNumber === issue.issueNumber ? (
+                    <div className="setup-form">
+                      <label className="field-group">
+                        <span className="field-label">Lane name</span>
+                        <input
+                          className="text-field"
+                          list="lane-suggestion-options"
+                          value={laneDraft}
+                          onChange={(event) => setLaneDraft(event.target.value)}
+                          placeholder="Delivery, Experience, Operations..."
+                        />
+                      </label>
+                      <div className="inline-actions">
+                        <button
+                          className="action-button action-button-primary"
+                          disabled={busyAction === `save-issue-lane-${issue.issueNumber}`}
+                          onClick={() => void handleSaveIssueLaneAssignment(issue.issueNumber)}
+                        >
+                          {busyAction === `save-issue-lane-${issue.issueNumber}`
+                            ? "Saving..."
+                            : issue.ownerKind === "lane"
+                              ? "Move lane"
+                              : "Set lane"}
+                        </button>
+                        <button
+                          className="action-button action-button-secondary"
+                          onClick={() => {
+                            setEditingLaneIssueNumber(null);
+                            setLaneDraft("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="inline-actions">
+                      <button
+                        className="action-button action-button-secondary"
+                        onClick={() => {
+                          setEditingLaneIssueNumber(issue.issueNumber);
+                          setLaneDraft(issue.laneName ?? issue.preferredLaneName ?? "Delivery");
+                        }}
+                      >
+                        {issue.ownerKind === "lane" ? "Change lane" : "Set target lane"}
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
             />
+            <datalist id="lane-suggestion-options">
+              {(status?.laneSuggestions ?? []).map((lane) => (
+                <option key={lane.id} value={lane.name}>
+                  {lane.issueCount > 0 ? `${lane.issueCount} open issues` : "No open issues yet"}
+                </option>
+              ))}
+            </datalist>
           </section>
 
           <section className="panel sidebar-card">

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -12,6 +12,7 @@ import type {
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
   SetupStatusResponse,
+  UpdateIssueLaneAssignmentInput,
   UpdateProjectSettingsInput
 } from "@director-os/shared";
 
@@ -26,6 +27,7 @@ export type {
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
   SetupStatusResponse,
+  UpdateIssueLaneAssignmentInput,
   UpdateProjectSettingsInput
 } from "@director-os/shared";
 
@@ -111,6 +113,11 @@ function createHttpDirectorClient(): WebDirectorClient {
         method: "POST",
         body: JSON.stringify(input)
       }),
+    updateIssueLaneAssignment: (issueNumber: number, input: UpdateIssueLaneAssignmentInput) =>
+      requestJson<DirectorStatusResponse>(`/api/issues/${issueNumber}/lane`, {
+        method: "POST",
+        body: JSON.stringify(input)
+      }),
     resetRouterRuntime: () =>
       requestJson<DirectorOperationResponse>("/api/reset-router-runtime", {
         method: "POST"
@@ -133,6 +140,8 @@ function createIpcDirectorClient(bridge: DirectorDesktopBridge): WebDirectorClie
     sync: () => bridge.director.sync(),
     updateProjectSettings: (input: UpdateProjectSettingsInput) =>
       bridge.director.updateProjectSettings(input),
+    updateIssueLaneAssignment: (issueNumber: number, input: UpdateIssueLaneAssignmentInput) =>
+      bridge.director.updateIssueLaneAssignment(issueNumber, input),
     resetRouterRuntime: () => bridge.director.resetRouterRuntime()
   };
 }
@@ -201,6 +210,13 @@ export async function updateProjectSettings(
   input: UpdateProjectSettingsInput
 ): Promise<DirectorStatusResponse> {
   return getDirectorClient().updateProjectSettings(input);
+}
+
+export async function updateIssueLaneAssignment(
+  issueNumber: number,
+  input: UpdateIssueLaneAssignmentInput
+): Promise<DirectorStatusResponse> {
+  return getDirectorClient().updateIssueLaneAssignment(issueNumber, input);
 }
 
 export async function resetRouterRuntime(): Promise<DirectorOperationResponse> {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -17,6 +17,7 @@ import {
   startOrchestrator,
   sendConversationMessage,
   syncProject,
+  updateIssueLaneAssignment,
   updateProjectSettings
 } from "./services.js";
 
@@ -103,6 +104,16 @@ export async function createDirectorServer() {
       model: string;
     };
   }>("/api/project/settings", async (request) => updateProjectSettings(request.body));
+  app.post<{
+    Params: {
+      issueNumber: string;
+    };
+    Body: {
+      laneName: string;
+    };
+  }>("/api/issues/:issueNumber/lane", async (request) =>
+    updateIssueLaneAssignment(Number(request.params.issueNumber), request.body)
+  );
   app.post("/api/reset-router-runtime", async () => resetRouterRuntime());
 
   app.setNotFoundHandler(async (request, reply) => {

--- a/packages/core/src/services.test.ts
+++ b/packages/core/src/services.test.ts
@@ -21,12 +21,15 @@ import {
   buildSyntheticIssueRecord,
   ensureIssueWorktree,
   isPrSweepDue,
+  preferredLaneForIssue,
   queueChiefOfStaffReviewFromLaneState,
+  reassignIssueLaneInRouter,
   reconcileProjectConfigWithRepository,
   resolveLastSuccessfulSyncAt,
   schedulePrSweepState,
   sortQueueableIssues,
   startPrSweepState,
+  synthesizeLaneSuggestions,
   synthesizeProjectConfigStatus,
   updateRunningPrSweepState
 } from "./services.js";
@@ -302,6 +305,125 @@ describe("synthesizeProjectConfigStatus", () => {
         "Targeting base branch main, but the local repo default branch could not be detected yet.",
       canHealToRepoDefault: false
     });
+  });
+});
+
+describe("lane assignment helpers", () => {
+  it("distinguishes explicit lane labels from the default fallback lane", () => {
+    expect(
+      preferredLaneForIssue(
+        makeIssueRecord(89, {
+          labels: ["director:lane:experience"]
+        })
+      )
+    ).toEqual({
+      id: "experience",
+      name: "Experience",
+      source: "explicit"
+    });
+
+    expect(preferredLaneForIssue(makeIssueRecord(30))).toEqual({
+      id: "delivery",
+      name: "Delivery",
+      source: "fallback"
+    });
+  });
+
+  it("builds lane suggestions from active lanes and open issue preferences", () => {
+    const suggestions = synthesizeLaneSuggestions(
+      [
+        makeIssueRecord(30),
+        makeIssueRecord(36, {
+          labels: ["director:lane:experience"]
+        }),
+        makeIssueRecord(79, {
+          labels: ["director:lane:experience"]
+        })
+      ],
+      [
+        {
+          id: "delivery",
+          name: "Delivery",
+          sessionId: "lane-delivery",
+          issueNumbers: [30],
+          status: "implementing",
+          currentIssueNumber: 30,
+          activePullRequestNumber: null,
+          lastSummary: "Working issue #30.",
+          lastPlanSummary: null,
+          updatedAt: "2026-04-06T00:00:00.000Z"
+        }
+      ]
+    );
+
+    expect(suggestions).toEqual([
+      {
+        id: "delivery",
+        name: "Delivery",
+        isActive: true,
+        issueCount: 1
+      },
+      {
+        id: "experience",
+        name: "Experience",
+        isActive: false,
+        issueCount: 2
+      }
+    ]);
+  });
+
+  it("reassigns active lane ownership and pending handoffs together", () => {
+    const router: RouterState = {
+      ...createDefaultRouterState("director-os"),
+      lanes: [
+        {
+          id: "delivery",
+          name: "Delivery",
+          sessionId: "lane-delivery",
+          issueNumbers: [79],
+          status: "implementing",
+          currentIssueNumber: 79,
+          activePullRequestNumber: null,
+          lastSummary: "Implementing issue #79.",
+          lastPlanSummary: null,
+          updatedAt: "2026-04-06T00:00:00.000Z"
+        }
+      ],
+      issueOwnership: {
+        "79": "delivery"
+      },
+      pendingHandoffs: [
+        {
+          id: "handoff_79",
+          laneId: "delivery",
+          issueNumber: 79,
+          kind: "implement",
+          status: "pending",
+          summary: "Implement issue #79.",
+          prNumber: null,
+          branchName: "codex/issue-79-parallel-lanes",
+          worktreePath: "/tmp/director-os/worktrees/issue-79",
+          startedAt: null,
+          startedBy: null,
+          startedByPid: null,
+          reviewWindowEndsAt: null,
+          lastHandledCommentAt: null,
+          details: null,
+          createdAt: "2026-04-06T00:00:00.000Z",
+          updatedAt: "2026-04-06T00:00:00.000Z"
+        }
+      ]
+    };
+
+    const lane = reassignIssueLaneInRouter(router, 79, "experience", "Experience");
+
+    expect(lane.id).toBe("experience");
+    expect(lane.name).toBe("Experience");
+    expect(lane.status).toBe("implementing");
+    expect(router.issueOwnership["79"]).toBe("experience");
+    expect(router.lanes.find((candidate) => candidate.id === "delivery")?.issueNumbers).toEqual([]);
+    expect(router.lanes.find((candidate) => candidate.id === "experience")?.issueNumbers).toEqual([79]);
+    expect(router.pendingHandoffs[0]?.laneId).toBe("experience");
   });
 });
 

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -17,6 +17,7 @@ import type {
   InitCommandOptions,
   IssueOwnershipRecord,
   LaneRecord,
+  LaneSuggestionRecord,
   OrchestratorStatusRecord,
   ProjectConfigStatusRecord,
   ProjectRecord,
@@ -27,6 +28,7 @@ import type {
   SetupProbeRepositoryInput,
   SetupRepositoryDraft,
   SetupStatusResponse,
+  UpdateIssueLaneAssignmentInput,
   UpdateProjectSettingsInput
 } from "@director-os/shared";
 
@@ -50,6 +52,7 @@ import {
 } from "./config.js";
 import { COS_TASK_APPENDICES, buildChiefOfStaffPrompt } from "./cos.js";
 import {
+  addIssueLabels,
   closePullRequest,
   commentOnIssue,
   createIssue,
@@ -65,6 +68,7 @@ import {
   probeRepositoryPath,
   pullRequestChecks,
   pullRequestDiff,
+  removeIssueLabels,
   resolveRepoPath,
   viewPullRequest
 } from "./github.js";
@@ -1325,24 +1329,156 @@ function assignIssueToChiefOfStaff(router: RouterState, issueNumber: number): vo
   router.issueOwnership[String(issueNumber)] = CHIEF_OF_STAFF_OWNER_ID;
 }
 
-function defaultLaneForIssue(issue: GitHubIssueRecord): { id: string; name: string } {
-  const explicitLabel = issue.labels.find((label) => label.startsWith("director:lane:"));
+function humanizeLaneName(rawName: string): string {
+  const trimmed = rawName.trim();
+  if (!trimmed) {
+    return "Delivery";
+  }
+
+  if (/[A-Z]/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed
+    .split(/[-_\s]+/)
+    .map((part) => (part ? `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}` : part))
+    .join(" ");
+}
+
+function laneDescriptorFromName(rawName: string): { id: string; name: string } {
+  const trimmed = rawName.trim();
+  const resolvedName = trimmed || "Delivery";
+  return {
+    id: slugify(resolvedName) || "delivery",
+    name: humanizeLaneName(resolvedName)
+  };
+}
+
+function explicitLaneLabelForIssue(issue: Pick<GitHubIssueRecord, "labels">): string | null {
+  return issue.labels.find((label) => label.startsWith("director:lane:")) ?? null;
+}
+
+export function preferredLaneForIssue(
+  issue: Pick<GitHubIssueRecord, "labels">
+): { id: string; name: string; source: "explicit" | "fallback" } {
+  const explicitLabel = explicitLaneLabelForIssue(issue);
   if (explicitLabel) {
-    const rawName = explicitLabel.slice("director:lane:".length).trim();
-    const normalized = rawName || "delivery";
+    const descriptor = laneDescriptorFromName(
+      explicitLabel.slice("director:lane:".length).trim() || "delivery"
+    );
     return {
-      id: slugify(normalized),
-      name: normalized
-        .split(/[-_\s]+/)
-        .map((part) => (part ? `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}` : part))
-        .join(" ")
+      ...descriptor,
+      source: "explicit"
     };
   }
 
   return {
     id: "delivery",
-    name: "Delivery"
+    name: "Delivery",
+    source: "fallback"
   };
+}
+
+function defaultLaneForIssue(issue: GitHubIssueRecord): { id: string; name: string } {
+  const preferredLane = preferredLaneForIssue(issue);
+  return {
+    id: preferredLane.id,
+    name: preferredLane.name
+  };
+}
+
+export function reassignIssueLaneInRouter(
+  router: RouterState,
+  issueNumber: number,
+  laneId: string,
+  laneName: string
+): RouterLaneState {
+  const previousLane = findIssueLane(router, issueNumber);
+  const previousLaneSnapshot = previousLane
+    ? {
+        status: previousLane.status,
+        lastSummary: previousLane.lastSummary,
+        lastPlanSummary: previousLane.lastPlanSummary,
+        activePullRequestNumber: previousLane.activePullRequestNumber
+      }
+    : null;
+  const nextLane = assignIssueToLane(router, issueNumber, laneId, laneName);
+
+  if (previousLaneSnapshot) {
+    nextLane.status = previousLaneSnapshot.status;
+    nextLane.lastSummary = previousLaneSnapshot.lastSummary;
+    nextLane.lastPlanSummary = previousLaneSnapshot.lastPlanSummary;
+    nextLane.activePullRequestNumber = previousLaneSnapshot.activePullRequestNumber;
+    nextLane.updatedAt = nowIso();
+  }
+
+  for (const handoff of router.pendingHandoffs) {
+    if (handoff.issueNumber === issueNumber && handoff.status !== "completed") {
+      handoff.laneId = laneId;
+      handoff.updatedAt = nowIso();
+    }
+  }
+
+  return nextLane;
+}
+
+export function synthesizeLaneSuggestions(
+  issues: GitHubIssueRecord[],
+  lanes: RouterLaneState[]
+): LaneSuggestionRecord[] {
+  const suggestions = new Map<string, LaneSuggestionRecord>();
+
+  const ensureSuggestion = (id: string, name: string, isActive: boolean) => {
+    const existing = suggestions.get(id);
+    if (existing) {
+      if (!existing.isActive) {
+        existing.name = name;
+      }
+      existing.isActive = existing.isActive || isActive;
+      return existing;
+    }
+
+    const created: LaneSuggestionRecord = {
+      id,
+      name,
+      isActive,
+      issueCount: 0
+    };
+    suggestions.set(id, created);
+    return created;
+  };
+
+  ensureSuggestion("delivery", "Delivery", lanes.some((lane) => lane.id === "delivery"));
+
+  for (const lane of lanes) {
+    ensureSuggestion(lane.id, lane.name, true);
+  }
+
+  for (const issue of issues) {
+    if (issue.state.toLowerCase() !== "open") {
+      continue;
+    }
+
+    const preferredLane = preferredLaneForIssue(issue);
+    const suggestion = ensureSuggestion(preferredLane.id, preferredLane.name, false);
+    suggestion.issueCount += 1;
+  }
+
+  return [...suggestions.values()].sort((left, right) => {
+    if (left.isActive !== right.isActive) {
+      return left.isActive ? -1 : 1;
+    }
+    if (left.issueCount !== right.issueCount) {
+      return right.issueCount - left.issueCount;
+    }
+    if (left.id === "delivery" && right.id !== "delivery") {
+      return -1;
+    }
+    if (right.id === "delivery" && left.id !== "delivery") {
+      return 1;
+    }
+    return left.name.localeCompare(right.name);
+  });
 }
 
 function defaultExecutionIntentForIssue(issue: GitHubIssueRecord): "plan" | "implement" {
@@ -1930,10 +2066,12 @@ function synthesizeLaneRecord(
 function synthesizeIssueOwnership(
   issue: GitHubIssueRecord,
   router: RouterState,
-  pullRequests: GitHubPullRequestRecord[]
+  pullRequests: GitHubPullRequestRecord[],
+  preferredLaneIssueCounts: ReadonlyMap<string, number>
 ): IssueOwnershipRecord {
   const ownerId = issueOwnerId(router, issue.number);
   const lane = findIssueLane(router, issue.number);
+  const preferredLane = preferredLaneForIssue(issue);
   const ownerKind =
     ownerId === CHIEF_OF_STAFF_OWNER_ID ? "chief_of_staff" : lane ? "lane" : null;
   const linkedPullRequest =
@@ -1950,6 +2088,13 @@ function synthesizeIssueOwnership(
       ownerKind === "chief_of_staff" ? "Chief of Staff" : ownerKind === "lane" ? lane?.name ?? null : null,
     laneId: lane?.id ?? null,
     laneName: lane?.name ?? null,
+    preferredLaneId: preferredLane.id,
+    preferredLaneName: preferredLane.name,
+    preferredLaneSource: preferredLane.source,
+    sharedLaneIssueCount:
+      issue.state.toLowerCase() === "open"
+        ? preferredLaneIssueCounts.get(preferredLane.id) ?? 1
+        : 0,
     executionIntent: lane?.status === "planning" ? "plan" : lane ? "implement" : null,
     status:
       issue.state.toLowerCase() !== "open"
@@ -5108,6 +5253,87 @@ export async function updateProjectSettings(
   });
 }
 
+export async function updateIssueLaneAssignment(
+  issueNumber: number,
+  input: UpdateIssueLaneAssignmentInput
+): Promise<DirectorStatusResponse> {
+  const normalizedIssueNumber = Number(issueNumber);
+  if (!Number.isInteger(normalizedIssueNumber) || normalizedIssueNumber <= 0) {
+    throw new Error("A valid issue number is required.");
+  }
+
+  const laneName = input.laneName.trim();
+  if (!laneName) {
+    throw new Error("Lane name is required.");
+  }
+
+  return withProject(async (session) => {
+    const [router, cache] = await Promise.all([
+      loadRouterState(session.paths, session.project.slug),
+      loadGitHubCacheState(session.paths, session.project.slug)
+    ]);
+
+    const targetIssue = cache.issues.find((issue) => issue.number === normalizedIssueNumber) ?? null;
+    if (!targetIssue) {
+      throw new Error(`Issue #${normalizedIssueNumber} is not available in the local GitHub cache.`);
+    }
+
+    const laneDescriptor = laneDescriptorFromName(laneName);
+    const nextLaneLabel = `director:lane:${laneDescriptor.id}`;
+    const labelsToRemove = targetIssue.labels.filter(
+      (label) => label.startsWith("director:lane:") && label !== nextLaneLabel
+    );
+    const labelsToAdd = targetIssue.labels.includes(nextLaneLabel) ? [] : [nextLaneLabel];
+
+    if (labelsToRemove.length > 0) {
+      await removeIssueLabels(session.project.repoSlug, normalizedIssueNumber, labelsToRemove);
+    }
+    if (labelsToAdd.length > 0) {
+      await addIssueLabels(session.project.repoSlug, normalizedIssueNumber, labelsToAdd);
+    }
+
+    const nextCache: GitHubCacheState = {
+      ...cache,
+      issues: cache.issues.map((issue) =>
+        issue.number === normalizedIssueNumber
+          ? {
+              ...issue,
+              labels: [
+                ...issue.labels.filter((label) => !label.startsWith("director:lane:")),
+                nextLaneLabel
+              ],
+              updatedAt: nowIso()
+            }
+          : issue
+      )
+    };
+    await saveGitHubCacheState(session.paths, nextCache, session.project.slug);
+
+    const ownerId = issueOwnerId(router, normalizedIssueNumber);
+    const hasLaneRuntimeState =
+      Boolean(findIssueLane(router, normalizedIssueNumber)) ||
+      (ownerId !== null && ownerId !== CHIEF_OF_STAFF_OWNER_ID) ||
+      router.pendingHandoffs.some(
+        (handoff) =>
+          handoff.issueNumber === normalizedIssueNumber &&
+          handoff.status !== "completed"
+      );
+
+    if (hasLaneRuntimeState) {
+      reassignIssueLaneInRouter(
+        router,
+        normalizedIssueNumber,
+        laneDescriptor.id,
+        laneDescriptor.name
+      );
+      router.updatedAt = nowIso();
+      await saveRouterState(session.paths, router);
+    }
+
+    return getDirectorStatus();
+  });
+}
+
 export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
   return withProject(async (session) => {
     const [router, cache, owner, currentBranch, repoDefaultBranch] = await Promise.all([
@@ -5125,6 +5351,17 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
     const openPullRequests = pullRequests
       .filter((pullRequest) => pullRequest.state.toLowerCase() === "open")
       .sort((left, right) => left.number - right.number);
+    const preferredLaneIssueCounts = new Map<string, number>();
+    for (const issue of issues) {
+      if (issue.state.toLowerCase() !== "open") {
+        continue;
+      }
+      const preferredLane = preferredLaneForIssue(issue);
+      preferredLaneIssueCounts.set(
+        preferredLane.id,
+        (preferredLaneIssueCounts.get(preferredLane.id) ?? 0) + 1
+      );
+    }
 
     return {
       project: session.project,
@@ -5136,7 +5373,10 @@ export async function getDirectorStatus(): Promise<DirectorStatusResponse> {
       lastSuccessfulSyncAt: resolveLastSuccessfulSyncAt(router.lastSyncAt, cache.syncedAt),
       prSweep: synthesizePrSweepRecord(router),
       lanes: router.lanes.map((lane) => synthesizeLaneRecord(lane, openPullRequests)),
-      issues: issues.map((issue) => synthesizeIssueOwnership(issue, router, pullRequests)),
+      laneSuggestions: synthesizeLaneSuggestions(issues, router.lanes),
+      issues: issues.map((issue) =>
+        synthesizeIssueOwnership(issue, router, pullRequests, preferredLaneIssueCounts)
+      ),
       openQuestion: router.openQuestion ? toHumanQuestionRecord(router.openQuestion) : null,
       recentActivity: synthesizeActivity(router),
       openPullRequests

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -256,6 +256,13 @@ export interface LaneRecord {
   updatedAt: string;
 }
 
+export interface LaneSuggestionRecord {
+  id: string;
+  name: string;
+  isActive: boolean;
+  issueCount: number;
+}
+
 export interface IssueOwnershipRecord {
   issueNumber: number;
   title: string;
@@ -266,6 +273,10 @@ export interface IssueOwnershipRecord {
   ownerName: string | null;
   laneId: string | null;
   laneName: string | null;
+  preferredLaneId: string | null;
+  preferredLaneName: string | null;
+  preferredLaneSource: "explicit" | "fallback" | null;
+  sharedLaneIssueCount: number;
   executionIntent: "plan" | "implement" | null;
   status: IssueRoutingStatus;
   linkedPullRequestNumber: number | null;
@@ -375,6 +386,7 @@ export interface DirectorStatusResponse {
   lastSuccessfulSyncAt: string | null;
   prSweep: PrSweepRecord | null;
   lanes: LaneRecord[];
+  laneSuggestions: LaneSuggestionRecord[];
   issues: IssueOwnershipRecord[];
   openQuestion: HumanQuestionRecord | null;
   recentActivity: ActivityRecord[];
@@ -404,6 +416,10 @@ export interface UpdateProjectSettingsInput {
   model: string;
 }
 
+export interface UpdateIssueLaneAssignmentInput {
+  laneName: string;
+}
+
 export interface DirectorClient {
   getSetupStatus(): Promise<SetupStatusResponse>;
   probeRepository(input: SetupProbeRepositoryInput): Promise<SetupStatusResponse>;
@@ -416,6 +432,10 @@ export interface DirectorClient {
   pause(reason?: string): Promise<DirectorOperationResponse>;
   sync(): Promise<DirectorOperationResponse>;
   updateProjectSettings(input: UpdateProjectSettingsInput): Promise<DirectorStatusResponse>;
+  updateIssueLaneAssignment(
+    issueNumber: number,
+    input: UpdateIssueLaneAssignmentInput
+  ): Promise<DirectorStatusResponse>;
   resetRouterRuntime(): Promise<DirectorOperationResponse>;
 }
 
@@ -436,6 +456,10 @@ export interface DirectorDesktopBridge {
     pause(reason?: string): Promise<DirectorOperationResponse>;
     sync(): Promise<DirectorOperationResponse>;
     updateProjectSettings(input: UpdateProjectSettingsInput): Promise<DirectorStatusResponse>;
+    updateIssueLaneAssignment(
+      issueNumber: number,
+      input: UpdateIssueLaneAssignmentInput
+    ): Promise<DirectorStatusResponse>;
     resetRouterRuntime(): Promise<DirectorOperationResponse>;
   };
 }


### PR DESCRIPTION
## Summary
- expose issue lane routing in the Control Room, including active lane, preferred lane, and whether the assignment is explicit or fallback
- add an inline lane reassignment flow that updates the durable GitHub lane label and live router state together
- add shared contracts, API/server plumbing, and regression tests for lane preference, lane suggestions, and lane reassignment

## Testing
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`

Closes #89